### PR TITLE
Bug36 select modes

### DIFF
--- a/dmxlights.go
+++ b/dmxlights.go
@@ -291,14 +291,14 @@ func main() {
 		}
 
 		if newSequence.Type == "rgb" && newSequence.Label == "chaser" {
-			this.FunctionLabels[0] = "Chaser\nPatten"
-			this.FunctionLabels[1] = "Chaser\nAuto\nColor"
-			this.FunctionLabels[2] = "Chaser\nAuto\nPatten"
-			this.FunctionLabels[3] = "Chaser\nBounce"
-			this.FunctionLabels[4] = "Chaser\nColor"
-			this.FunctionLabels[5] = "Chaser\nStatic\nColor"
-			this.FunctionLabels[6] = "Chaser\nInvert"
-			this.FunctionLabels[7] = "Chaser\nMusic"
+			this.FunctionLabels[0] = "Chase\nPatten"
+			this.FunctionLabels[1] = "Chase\nAuto\nColor"
+			this.FunctionLabels[2] = "Chase\nAuto\nPatten"
+			this.FunctionLabels[3] = "Chase\nBounce"
+			this.FunctionLabels[4] = "Chase\nColor"
+			this.FunctionLabels[5] = "Chase\nStatic\nColor"
+			this.FunctionLabels[6] = "Chase\nInvert"
+			this.FunctionLabels[7] = "Chase\nMusic"
 		}
 
 		// Make functions for each of the sequences.

--- a/dmxlights.go
+++ b/dmxlights.go
@@ -78,7 +78,7 @@ func main() {
 	this.SelectButtonPressed = make([]bool, NumberOfSequences)     // Initialise four select buttons.
 	this.SelectMode = make([]int, NumberOfSequences)               // Initialise four mode variables.
 	this.LastMode = make([]int, NumberOfSequences)                 // Initialise four mode variables.
-	this.EditSequenceColorPickerMode = false                       // Remember when we are in editing sequence colors mode.
+	this.ShowRGBColorPicker = false                                // Remember when we are in editing sequence colors mode.
 	this.EditScannerColorsMode = false                             // Remember when we are in setting scanner color mode.
 	this.EditGoboSelectionMode = false                             // Remember when we are in selecting gobo mode.
 	this.EditStaticColorsMode = make([]bool, NumberOfSequences)    // Remember when we are in editing static colors mode.

--- a/dmxlights.go
+++ b/dmxlights.go
@@ -82,6 +82,7 @@ func main() {
 	this.EditScannerColorsMode = false                             // Remember when we are in setting scanner color mode.
 	this.EditGoboSelectionMode = false                             // Remember when we are in selecting gobo mode.
 	this.EditStaticColorsMode = make([]bool, NumberOfSequences)    // Remember when we are in editing static colors mode.
+	this.StaticFlashing = make([]bool, NumberOfSequences)          // Remember when we are in static buttons are flashing.
 	this.EditPatternMode = false                                   // Remember when we are in editing pattern mode.
 	this.StaticButtons = makeStaticButtonsStorage()                // Make storgage for color editing button results.
 	this.PresetsStore = presets.LoadPresets()                      // Load the presets from their json files.

--- a/dmxlights.go
+++ b/dmxlights.go
@@ -78,7 +78,7 @@ func main() {
 	this.SelectButtonPressed = make([]bool, NumberOfSequences)     // Initialise four select buttons.
 	this.SelectMode = make([]int, NumberOfSequences)               // Initialise four mode variables.
 	this.LastMode = make([]int, NumberOfSequences)                 // Initialise four mode variables.
-	this.EditSequenceColorsMode = false                            // Remember when we are in editing sequence colors mode.
+	this.EditSequenceColorPickerMode = false                       // Remember when we are in editing sequence colors mode.
 	this.EditScannerColorsMode = false                             // Remember when we are in setting scanner color mode.
 	this.EditGoboSelectionMode = false                             // Remember when we are in selecting gobo mode.
 	this.EditStaticColorsMode = make([]bool, NumberOfSequences)    // Remember when we are in editing static colors mode.

--- a/dmxlights.go
+++ b/dmxlights.go
@@ -95,6 +95,7 @@ func main() {
 	this.StrobeSpeed = make(map[int]int, NumberOfSequences)        // Initialise storage for four sequences.
 	this.LastStrobeSpeed = make(map[int]int, NumberOfSequences)    // Initialise storage for four sequences.
 	this.ClearPressed = make(map[int]bool, NumberOfSequences)      // Initialise storage for four sequences.
+	this.ScannerChaser = make(map[int]bool, NumberOfSequences)     // Initialise storage for four sequences.
 	this.ScannerCoordinates = make(map[int]int, NumberOfSequences) // Number of coordinates for scanner patterns is selected from 4 choices. 0=12, 1=16,2=24,3=32,4=64
 	this.LaunchPadConnected = true                                 // Assume launchpad is present, until tested.
 	this.DmxInterfacePresent = true                                // Assume DMX interface card is present, until tested.

--- a/dmxlights.go
+++ b/dmxlights.go
@@ -83,6 +83,7 @@ func main() {
 	this.EditGoboSelectionMode = false                             // Remember when we are in selecting gobo mode.
 	this.EditStaticColorsMode = make([]bool, NumberOfSequences)    // Remember when we are in editing static colors mode.
 	this.StaticFlashing = make([]bool, NumberOfSequences)          // Remember when we are in static buttons are flashing.
+	this.SequenceType = make([]string, NumberOfSequences)          // Remember sequence type.
 	this.EditPatternMode = false                                   // Remember when we are in editing pattern mode.
 	this.StaticButtons = makeStaticButtonsStorage()                // Make storgage for color editing button results.
 	this.PresetsStore = presets.LoadPresets()                      // Load the presets from their json files.
@@ -251,6 +252,7 @@ func main() {
 		this.StrobeSpeed[sequenceNumber] = 255                                       // Set the strob speed to be the fastest for this sequence.
 		this.RGBShift[sequenceNumber] = common.DEFAULT_RGB_SHIFT                     // Default RGB shift size.
 		this.ScannerShift[sequenceNumber] = common.DEFAULT_SCANNER_SHIFT             // Default scanner shift size.
+		this.SequenceType[sequenceNumber] = newSequence.Type                         // Set the sequence type.
 		this.RGBSize[sequenceNumber] = common.DEFAULT_RGB_SIZE                       // Set the defaults size for the RGB fixtures.
 		this.ScannerSize[sequenceNumber] = common.DEFAULT_SCANNER_SIZE               // Set the defaults size for the scanner fixtures.
 		this.RGBFade[sequenceNumber] = common.DEFAULT_RGB_FADE                       // Set the default fade time for RGB fixtures.

--- a/pkg/buttons/buttons.go
+++ b/pkg/buttons/buttons.go
@@ -947,6 +947,7 @@ func ProcessButtons(X int, Y int,
 
 		this.EditSequenceColorsMode = false
 		this.EditGoboSelectionMode = false
+		this.DisplayChaserShortCut = false
 
 		return
 	}
@@ -965,6 +966,7 @@ func ProcessButtons(X int, Y int,
 
 		this.EditSequenceColorsMode = false
 		this.EditGoboSelectionMode = false
+		this.DisplayChaserShortCut = false
 
 		return
 	}
@@ -1005,6 +1007,7 @@ func ProcessButtons(X int, Y int,
 
 		this.EditSequenceColorsMode = false
 		this.EditGoboSelectionMode = false
+		this.DisplayChaserShortCut = false
 
 		return
 	}
@@ -2427,5 +2430,23 @@ func clearAllModes(sequences []*common.Sequence, this *CurrentState) {
 		for function := range this.Functions {
 			this.Functions[sequenceNumber][function].State = false
 		}
+	}
+}
+
+func printMode(this *CurrentState) {
+	if this.SelectMode[this.DisplaySequence] == NORMAL {
+		fmt.Printf("PrintMode: this.SelectMode[%d] = NORMAL \n", this.TargetSequence)
+	}
+	if this.SelectMode[this.DisplaySequence] == CHASER_DISPLAY {
+		fmt.Printf("PrintMode: this.SelectMode[%d] = CHASER_DISPLAY \n", this.SelectedSequence)
+	}
+	if this.SelectMode[this.DisplaySequence] == FUNCTION {
+		fmt.Printf("PrintMode: this.SelectMode[%d] = FUNCTION \n", this.SelectedSequence)
+	}
+	if this.SelectMode[this.DisplaySequence] == CHASER_FUNCTION {
+		fmt.Printf("PrintMode: this.SelectMode[%d] = CHASER_FUNCTION \n", this.SelectedSequence)
+	}
+	if this.SelectMode[this.DisplaySequence] == STATUS {
+		fmt.Printf("PrintMode: this.SelectMode[%d] = STATUS \n", this.SelectedSequence)
 	}
 }

--- a/pkg/buttons/buttons.go
+++ b/pkg/buttons/buttons.go
@@ -1048,6 +1048,7 @@ func ProcessButtons(X int, Y int,
 			common.SendCommandToSequence(this.SelectedSequence, cmd, commandChannels)
 
 			this.Running[this.SelectedSequence] = false
+			this.Functions[this.SelectedSequence][common.Function8_Music_Trigger].State = false
 
 			// Stop should also stop the shutter chaser.
 			if this.SelectedType == "scanner" && this.ScannerChaser[this.SelectedSequence] {

--- a/pkg/buttons/buttons.go
+++ b/pkg/buttons/buttons.go
@@ -138,6 +138,9 @@ func ProcessButtons(X int, Y int,
 		fmt.Printf("ProcessButtons Called with X:%d Y:%d\n", X, Y)
 	}
 
+	// Set the sequence type.
+	this.SelectedType = sequences[this.SelectedSequence].Type
+
 	// The Novation Launchpad is not designed for the number of MIDI
 	// Events we send when all the sequences are chasing at top
 	// Speed, so we look out for the crys for help when the Launchpad
@@ -697,7 +700,7 @@ func ProcessButtons(X int, Y int,
 			common.SendCommandToSequence(this.TargetSequence, cmd, commandChannels)
 
 			// Update the status bar
-			common.UpdateStatusBar(fmt.Sprintf("Shift %02d", this.RGBShift[this.TargetSequence]), "shift", false, guiButtons)
+			UpdateShift(this.TargetSequence, this.SelectMode[this.DisplaySequence], this.RGBShift[this.TargetSequence], this.SelectedType, guiButtons)
 			return
 		}
 
@@ -716,7 +719,7 @@ func ProcessButtons(X int, Y int,
 
 			// Update the status bar
 			label := getScannerShiftLabel(this.ScannerShift[this.TargetSequence])
-			common.UpdateStatusBar(fmt.Sprintf("Shift %0s", label), "shift", false, guiButtons)
+			common.UpdateStatusBar(fmt.Sprintf("Rotate Shift %0s", label), "shift", false, guiButtons)
 			return
 		}
 	}
@@ -751,7 +754,7 @@ func ProcessButtons(X int, Y int,
 			common.SendCommandToSequence(this.TargetSequence, cmd, commandChannels)
 
 			// Update the status bar
-			common.UpdateStatusBar(fmt.Sprintf("Shift %02d", this.RGBShift[this.TargetSequence]), "shift", false, guiButtons)
+			UpdateShift(this.TargetSequence, this.SelectMode[this.DisplaySequence], this.RGBShift[this.TargetSequence], this.SelectedType, guiButtons)
 			return
 		}
 
@@ -770,7 +773,7 @@ func ProcessButtons(X int, Y int,
 
 			// Update the status bar
 			label := getScannerShiftLabel(this.ScannerShift[this.TargetSequence])
-			common.UpdateStatusBar(fmt.Sprintf("Shift %s", label), "shift", false, guiButtons)
+			common.UpdateStatusBar(fmt.Sprintf("Rotate Shift %s", label), "shift", false, guiButtons)
 			return
 		}
 	}
@@ -848,7 +851,7 @@ func ProcessButtons(X int, Y int,
 		}
 
 		// Update the status bar
-		common.UpdateStatusBar(fmt.Sprintf("Speed %02d", this.Speed[this.TargetSequence]), "speed", false, guiButtons)
+		UpdateSpeed(this.TargetSequence, this.SelectMode[this.DisplaySequence], this.Speed[this.TargetSequence], this.SelectedType, guiButtons)
 
 		return
 	}
@@ -925,7 +928,7 @@ func ProcessButtons(X int, Y int,
 		}
 
 		// Update the status bar
-		common.UpdateStatusBar(fmt.Sprintf("Speed %02d", this.Speed[this.TargetSequence]), "speed", false, guiButtons)
+		UpdateSpeed(this.TargetSequence, this.SelectMode[this.DisplaySequence], this.Speed[this.TargetSequence], this.SelectedType, guiButtons)
 
 		return
 	}
@@ -1196,7 +1199,7 @@ func ProcessButtons(X int, Y int,
 			}
 			common.SendCommandToSequence(this.TargetSequence, cmd, commandChannels)
 			// Update the status bar
-			common.UpdateStatusBar(fmt.Sprintf("Size %02d", this.RGBSize[this.TargetSequence]), "size", false, guiButtons)
+			UpdateSize(this.TargetSequence, this.SelectMode[this.DisplaySequence], this.RGBSize[this.TargetSequence], this.SelectedType, guiButtons)
 			return
 		}
 
@@ -1215,7 +1218,7 @@ func ProcessButtons(X int, Y int,
 			common.SendCommandToSequence(this.TargetSequence, cmd, commandChannels)
 
 			// Update the status bar
-			common.UpdateStatusBar(fmt.Sprintf("Size %02d", this.ScannerSize[this.TargetSequence]), "size", false, guiButtons)
+			common.UpdateStatusBar(fmt.Sprintf("Rotate Size %02d", this.ScannerSize[this.TargetSequence]), "size", false, guiButtons)
 			return
 		}
 	}
@@ -1251,7 +1254,7 @@ func ProcessButtons(X int, Y int,
 			}
 			common.SendCommandToSequence(this.TargetSequence, cmd, commandChannels)
 			// Update the status bar
-			common.UpdateStatusBar(fmt.Sprintf("Size %02d", this.RGBSize[this.TargetSequence]), "size", false, guiButtons)
+			UpdateSize(this.TargetSequence, this.SelectMode[this.DisplaySequence], this.RGBSize[this.TargetSequence], this.SelectedType, guiButtons)
 			return
 		}
 
@@ -1270,8 +1273,7 @@ func ProcessButtons(X int, Y int,
 			common.SendCommandToSequence(this.TargetSequence, cmd, commandChannels)
 
 			// Update the status bar
-			common.UpdateStatusBar(fmt.Sprintf("Size %02d", this.ScannerSize[this.TargetSequence]), "size", false, guiButtons)
-
+			common.UpdateStatusBar(fmt.Sprintf("Rotate Size %02d", this.ScannerSize[this.TargetSequence]), "size", false, guiButtons)
 			return
 		}
 	}
@@ -1306,8 +1308,7 @@ func ProcessButtons(X int, Y int,
 			}
 			common.SendCommandToSequence(this.TargetSequence, cmd, commandChannels)
 			// Update the status bar
-			common.UpdateStatusBar(fmt.Sprintf("Fade %02d", this.RGBFade[this.TargetSequence]), "fade", false, guiButtons)
-
+			UpdateFade(this.TargetSequence, this.SelectMode[this.DisplaySequence], this.RGBFade[this.TargetSequence], this.SelectedType, guiButtons)
 			return
 		}
 
@@ -1327,7 +1328,7 @@ func ProcessButtons(X int, Y int,
 			common.SendCommandToSequence(this.TargetSequence, cmd, commandChannels)
 			// Update the status bar
 			label := getScannerCoordinatesLabel(this.ScannerCoordinates[this.TargetSequence])
-			common.UpdateStatusBar(fmt.Sprintf("Coord %s", label), "fade", false, guiButtons)
+			common.UpdateStatusBar(fmt.Sprintf("Rotate Coord %s", label), "fade", false, guiButtons)
 			return
 		}
 
@@ -1363,7 +1364,7 @@ func ProcessButtons(X int, Y int,
 			}
 			common.SendCommandToSequence(this.TargetSequence, cmd, commandChannels)
 			// Update the status bar
-			common.UpdateStatusBar(fmt.Sprintf("Fade %02d", this.RGBFade[this.TargetSequence]), "fade", false, guiButtons)
+			UpdateFade(this.TargetSequence, this.SelectMode[this.DisplaySequence], this.RGBFade[this.TargetSequence], this.SelectedType, guiButtons)
 			return
 		}
 
@@ -1383,7 +1384,7 @@ func ProcessButtons(X int, Y int,
 			common.SendCommandToSequence(this.TargetSequence, cmd, commandChannels)
 			// Update the status bar
 			label := getScannerCoordinatesLabel(this.ScannerCoordinates[this.TargetSequence])
-			common.UpdateStatusBar(fmt.Sprintf("Coord %s", label), "fade", false, guiButtons)
+			common.UpdateStatusBar(fmt.Sprintf("Rotate Coord %s", label), "fade", false, guiButtons)
 			return
 		}
 	}
@@ -2515,4 +2516,64 @@ func SequenceSelect(eventsForLauchpad chan common.ALight, guiButtons chan common
 		common.LightLamp(common.ALight{X: 8, Y: this.SelectedSequence, Brightness: 255, Red: 255, Green: 0, Blue: 255}, eventsForLauchpad, guiButtons)
 	}
 
+}
+
+func UpdateSpeed(sequenceNumber int, mode int, speed int, tYpe string, guiButttons chan common.ALight) {
+
+	if mode == NORMAL || mode == FUNCTION || mode == STATUS {
+		if tYpe == "rgb" {
+			common.UpdateStatusBar(fmt.Sprintf("Speed %02d", speed), "speed", false, guiButttons)
+		}
+		if tYpe == "scanner" {
+			common.UpdateStatusBar(fmt.Sprintf("Rotate Speed %02d", speed), "speed", false, guiButttons)
+		}
+	}
+	if mode == CHASER_DISPLAY || mode == CHASER_FUNCTION {
+		common.UpdateStatusBar(fmt.Sprintf("Chase Speed %02d", speed), "speed", false, guiButttons)
+	}
+}
+
+func UpdateSize(sequenceNumber int, mode int, size int, tYpe string, guiButttons chan common.ALight) {
+
+	if mode == NORMAL || mode == FUNCTION || mode == STATUS {
+		if tYpe == "rgb" {
+			common.UpdateStatusBar(fmt.Sprintf("Size %02d", size), "size", false, guiButttons)
+		}
+		if tYpe == "scanner" {
+			common.UpdateStatusBar(fmt.Sprintf("Rotate Size %02d", size), "size", false, guiButttons)
+		}
+	}
+	if mode == CHASER_DISPLAY || mode == CHASER_FUNCTION {
+		common.UpdateStatusBar(fmt.Sprintf("Chase Size %02d", size), "size", false, guiButttons)
+	}
+}
+
+func UpdateShift(sequenceNumber int, mode int, shift int, tYpe string, guiButttons chan common.ALight) {
+
+	if mode == NORMAL || mode == FUNCTION || mode == STATUS {
+		if tYpe == "rgb" {
+			common.UpdateStatusBar(fmt.Sprintf("Shift %02d", shift), "shift", false, guiButttons)
+		}
+		if tYpe == "scanner" {
+			common.UpdateStatusBar(fmt.Sprintf("Rotate Shift %02d", shift), "shift", false, guiButttons)
+		}
+	}
+	if mode == CHASER_DISPLAY || mode == CHASER_FUNCTION {
+		common.UpdateStatusBar(fmt.Sprintf("Chase Shift %02d", shift), "shift", false, guiButttons)
+	}
+}
+
+func UpdateFade(sequenceNumber int, mode int, fade int, tYpe string, guiButttons chan common.ALight) {
+
+	if mode == NORMAL || mode == FUNCTION || mode == STATUS {
+		if tYpe == "rgb" {
+			common.UpdateStatusBar(fmt.Sprintf("Fade %02d", fade), "fade", false, guiButttons)
+		}
+		if tYpe == "scanner" {
+			common.UpdateStatusBar(fmt.Sprintf("Rotate Fade %02d", fade), "fade", false, guiButttons)
+		}
+	}
+	if mode == CHASER_DISPLAY || mode == CHASER_FUNCTION {
+		common.UpdateStatusBar(fmt.Sprintf("Chase Fade %02d", fade), "fade", false, guiButttons)
+	}
 }

--- a/pkg/buttons/buttons.go
+++ b/pkg/buttons/buttons.go
@@ -48,7 +48,7 @@ const (
 type CurrentState struct {
 	MyWindow                    fyne.Window                // Pointer to main window.
 	GUI                         bool                       // Flag to indicate use of GUI.
-	Crash1                      bool                       // Flags to detect launpad crash.
+	Crash1                      bool                       // Flags to detect launchpad crash.
 	Crash2                      bool                       // Flags to detect launchpad crash.
 	SelectedSequence            int                        // The currently selected sequence.
 	TargetSequence              int                        // The current target sequence.

--- a/pkg/buttons/buttons.go
+++ b/pkg/buttons/buttons.go
@@ -2483,22 +2483,23 @@ func clearAllModes(sequences []*common.Sequence, this *CurrentState) {
 	}
 }
 
-func printMode(this *CurrentState) {
-	if this.SelectMode[this.DisplaySequence] == NORMAL {
-		fmt.Printf("PrintMode: this.SelectMode[%d] = NORMAL \n", this.TargetSequence)
+func printMode(sequencNumber int) string {
+	if sequencNumber == NORMAL {
+		return "NORMAL"
 	}
-	if this.SelectMode[this.DisplaySequence] == CHASER_DISPLAY {
-		fmt.Printf("PrintMode: this.SelectMode[%d] = CHASER_DISPLAY \n", this.SelectedSequence)
+	if sequencNumber == CHASER_DISPLAY {
+		return "CHASER_DISPLAY"
 	}
-	if this.SelectMode[this.DisplaySequence] == FUNCTION {
-		fmt.Printf("PrintMode: this.SelectMode[%d] = FUNCTION \n", this.SelectedSequence)
+	if sequencNumber == FUNCTION {
+		return "FUNCTION"
 	}
-	if this.SelectMode[this.DisplaySequence] == CHASER_FUNCTION {
-		fmt.Printf("PrintMode: this.SelectMode[%d] = CHASER_FUNCTION \n", this.SelectedSequence)
+	if sequencNumber == CHASER_FUNCTION {
+		return "CHASER_FUNCTION"
 	}
-	if this.SelectMode[this.DisplaySequence] == STATUS {
-		fmt.Printf("PrintMode: this.SelectMode[%d] = STATUS \n", this.SelectedSequence)
+	if sequencNumber == STATUS {
+		return "STATUS"
 	}
+	return "UNKNOWN"
 }
 
 func SequenceSelect(eventsForLauchpad chan common.ALight, guiButtons chan common.ALight, this *CurrentState) {
@@ -2520,7 +2521,7 @@ func SequenceSelect(eventsForLauchpad chan common.ALight, guiButtons chan common
 
 func UpdateSpeed(this *CurrentState, guiButttons chan common.ALight) {
 
-	mode := this.SelectMode[this.TargetSequence]
+	mode := this.SelectMode[this.DisplaySequence]
 	tYpe := this.SelectedType
 	speed := this.Speed[this.TargetSequence]
 
@@ -2539,7 +2540,7 @@ func UpdateSpeed(this *CurrentState, guiButttons chan common.ALight) {
 
 func UpdateSize(this *CurrentState, guiButttons chan common.ALight) {
 
-	mode := this.SelectMode[this.TargetSequence]
+	mode := this.SelectMode[this.DisplaySequence]
 	tYpe := this.SelectedType
 	size := this.RGBSize[this.TargetSequence]
 
@@ -2558,7 +2559,7 @@ func UpdateSize(this *CurrentState, guiButttons chan common.ALight) {
 
 func UpdateShift(this *CurrentState, guiButttons chan common.ALight) {
 
-	mode := this.SelectMode[this.TargetSequence]
+	mode := this.SelectMode[this.DisplaySequence]
 	tYpe := this.SelectedType
 	shift := this.RGBShift[this.TargetSequence]
 
@@ -2577,7 +2578,7 @@ func UpdateShift(this *CurrentState, guiButttons chan common.ALight) {
 
 func UpdateFade(this *CurrentState, guiButttons chan common.ALight) {
 
-	mode := this.SelectMode[this.TargetSequence]
+	mode := this.SelectMode[this.DisplaySequence]
 	tYpe := this.SelectedType
 	fade := this.RGBFade[this.TargetSequence]
 

--- a/pkg/buttons/buttons.go
+++ b/pkg/buttons/buttons.go
@@ -1872,11 +1872,11 @@ func ProcessButtons(X int, Y int,
 		this.TargetSequence = this.EditWhichStaticSequence
 		this.DisplaySequence = this.SelectedSequence
 
-		//if debug {
-		fmt.Printf("EditWhichStaticSequence %d\n", this.EditWhichStaticSequence)
-		fmt.Printf("TargetSequence %d\n", this.TargetSequence)
-		fmt.Printf("DisplaySequence %d\n", this.DisplaySequence)
-		//}
+		if debug {
+			fmt.Printf("EditWhichStaticSequence %d\n", this.EditWhichStaticSequence)
+			fmt.Printf("TargetSequence %d\n", this.TargetSequence)
+			fmt.Printf("DisplaySequence %d\n", this.DisplaySequence)
+		}
 
 		// Find the color from the button pressed.
 		color := FindCurrentColor(X, Y, *sequences[this.TargetSequence])

--- a/pkg/buttons/buttons.go
+++ b/pkg/buttons/buttons.go
@@ -2507,26 +2507,26 @@ func clearAllModes(sequences []*common.Sequence, this *CurrentState) {
 	}
 }
 
-func printMode(sequencNumber int) string {
-	if sequencNumber == NORMAL {
+func printMode(mode int) string {
+	if mode == NORMAL {
 		return "NORMAL"
 	}
-	if sequencNumber == NORMAL_STATIC {
+	if mode == NORMAL_STATIC {
 		return "NORMAL_STATIC"
 	}
-	if sequencNumber == CHASER_DISPLAY {
+	if mode == CHASER_DISPLAY {
 		return "CHASER_DISPLAY"
 	}
-	if sequencNumber == CHASER_DISPLAY_STATIC {
+	if mode == CHASER_DISPLAY_STATIC {
 		return "CHASER_DISPLAY_STATIC"
 	}
-	if sequencNumber == FUNCTION {
+	if mode == FUNCTION {
 		return "FUNCTION"
 	}
-	if sequencNumber == CHASER_FUNCTION {
+	if mode == CHASER_FUNCTION {
 		return "CHASER_FUNCTION"
 	}
-	if sequencNumber == STATUS {
+	if mode == STATUS {
 		return "STATUS"
 	}
 	return "UNKNOWN"

--- a/pkg/buttons/buttons.go
+++ b/pkg/buttons/buttons.go
@@ -1964,6 +1964,9 @@ func ProcessButtons(X int, Y int,
 		if this.SelectMode[this.SelectedSequence] == CHASER_FUNCTION {
 			this.TargetSequence = this.ChaserSequenceNumber
 			this.DisplaySequence = this.SelectedSequence
+			// This is the way we get the shutter chaser to be displayed as we exit
+			// the pattern selection
+			this.DisplayChaserShortCut = true
 			this.SelectMode[this.DisplaySequence] = CHASER_FUNCTION
 		} else {
 			this.TargetSequence = this.SelectedSequence

--- a/pkg/buttons/buttons.go
+++ b/pkg/buttons/buttons.go
@@ -1949,6 +1949,9 @@ func ProcessButtons(X int, Y int,
 		this.LastStaticColorButtonX = this.SelectedStaticFixtureNumber
 		this.LastStaticColorButtonY = Y
 
+		// Hide the sequence.
+		common.HideSequence(this.TargetSequence, commandChannels)
+
 		// We call ShowRGBColorPicker so you can see which static color has been selected for this fixture.
 		ShowRGBColorPicker(this.MasterBrightness, *sequences[this.TargetSequence], this.DisplaySequence, eventsForLaunchpad, guiButtons, commandChannels)
 

--- a/pkg/buttons/buttons.go
+++ b/pkg/buttons/buttons.go
@@ -75,7 +75,6 @@ type CurrentState struct {
 	Config                      bool                       // Flag to indicate we are in fixture config mode.
 	Blackout                    bool                       // Blackout all fixtures.
 	Flood                       bool                       // Flood all fixtures.
-	Loading                     bool                       // True while loading a config.
 	SelectMode                  []int                      // What mode each sequence is in : normal mode, function mode, status selection mode.
 	LastMode                    []int                      // Last mode sequence was in : normal mode, function mode, status selection mode.
 	Functions                   map[int][]common.Function  // Map indexed by sequence of functions

--- a/pkg/buttons/buttons.go
+++ b/pkg/buttons/buttons.go
@@ -2097,9 +2097,6 @@ func ShowRGBColorPicker(master int, targetSequence common.Sequence, displaySeque
 	for myFixtureNumber, lamp := range targetSequence.RGBAvailableColors {
 
 		lamp.Flash = false
-		if debug {
-			fmt.Printf("Static Color Button %+v\n", lamp)
-		}
 
 		// Check if we need to flash this button.
 		for index, availableColor := range targetSequence.RGBAvailableColors {

--- a/pkg/buttons/buttons.go
+++ b/pkg/buttons/buttons.go
@@ -1913,9 +1913,14 @@ func ProcessButtons(X int, Y int,
 		if this.SelectMode[this.SelectedSequence] == CHASER_FUNCTION {
 			this.TargetSequence = this.ChaserSequenceNumber
 			this.DisplaySequence = this.SelectedSequence
+			// This is the way we get the shutter chaser to be displayed as we exit
+			// the pattern selection
+			this.DisplayChaserShortCut = true
+			this.SelectMode[this.DisplaySequence] = CHASER_FUNCTION
 		} else {
 			this.TargetSequence = this.SelectedSequence
 			this.DisplaySequence = this.SelectedSequence
+			this.SelectMode[this.DisplaySequence] = NORMAL
 		}
 
 		if debug {
@@ -1930,8 +1935,6 @@ func ProcessButtons(X int, Y int,
 			},
 		}
 		common.SendCommandToSequence(this.TargetSequence, cmd, commandChannels)
-
-		this.SelectMode[this.DisplaySequence] = NORMAL
 
 		// Get an upto date copy of the sequence.
 		sequences[this.TargetSequence] = common.RefreshSequence(this.TargetSequence, commandChannels, updateChannels)

--- a/pkg/buttons/buttons.go
+++ b/pkg/buttons/buttons.go
@@ -39,10 +39,10 @@ const debug = false
 // Select modes.
 const (
 	NORMAL          int = iota // Normal RGB or Scanner Rotation display.
-	CHASER_DISPLAY             //  Show the scanner shutter display.
 	FUNCTION                   // Show the RGB or Scanner functions.
-	CHASER_FUNCTION            // Show the scammer shutter chaser functions.
 	STATUS                     // Show the fixture status states.
+	CHASER_DISPLAY             //  Show the scanner shutter display.
+	CHASER_FUNCTION            // Show the scammer shutter chaser functions.
 )
 
 type CurrentState struct {
@@ -81,11 +81,11 @@ type CurrentState struct {
 	FunctionLabels              [8]string                  // Storage for the function key labels for this sequence.
 	SelectButtonPressed         []bool                     // Which sequence has its Select button pressed.
 	SwitchPositions             [9][9]int                  // Sorage for switch positions.
-	EditSequenceColorPickerMode bool                       // This flag is true when the sequence is in when we are using the color picker.
+	ShowRGBColorPicker          bool                       // This flag is true when the sequence is in when we are showing the color picker.
 	EditScannerColorsMode       bool                       // This flag is true when the sequence is in select scanner colors editing mode.
 	EditGoboSelectionMode       bool                       // This flag is true when the sequence is in sequence gobo selection mode.
-	EditStaticColorsMode        []bool                     // This flag is true when the sequence is in static colors editing mode.
-	EditColorPicker             bool                       // This flag is true when the sequence is in color picker mode.
+	EditStaticColorsMode        []bool                     // This flag is true when the sequence is in edit static colors mode.
+	ShowStaticColorPicker       bool                       // This flag is true when the sequence is showing the static color picker mode.
 	EditWhichStaticSequence     int                        // Which static sequence is currently being edited.
 	EditPatternMode             bool                       // This flag is true when the sequence is in pattern editing mode.
 	EditFixtureSelectionMode    bool                       // This flag is true when the sequence is in select fixture mode.
@@ -183,8 +183,7 @@ func ProcessButtons(X int, Y int,
 		!this.Functions[Y][common.Function6_Static_Gobo].State &&
 		!this.Functions[Y][common.Function5_Color].State &&
 		!this.EditStaticColorsMode[Y] &&
-		!this.EditSequenceColorPickerMode &&
-		!this.EditColorPicker &&
+		!this.ShowRGBColorPicker &&
 		sequences[Y].Type != "switch" && // As long as we're not a switch sequence.
 		this.SelectMode[Y] == NORMAL { // As long as we're in normal mode for this sequence.
 
@@ -243,8 +242,8 @@ func ProcessButtons(X int, Y int,
 		!this.Functions[Y][common.Function1_Pattern].State &&
 		!this.Functions[Y][common.Function6_Static_Gobo].State &&
 		!this.Functions[Y][common.Function5_Color].State &&
-		!this.EditSequenceColorPickerMode &&
-		!this.EditColorPicker &&
+		!this.ShowRGBColorPicker &&
+		!this.ShowStaticColorPicker &&
 		sequences[Y].Type != "switch" && // As long as we're not a switch sequence.
 		this.SelectMode[Y] == NORMAL { // As long as we're in normal mode for this sequence.
 
@@ -600,8 +599,8 @@ func ProcessButtons(X int, Y int,
 			fmt.Printf("Ask For Config\n")
 		}
 
-		if this.EditSequenceColorPickerMode {
-			this.EditSequenceColorPickerMode = false
+		if this.ShowRGBColorPicker {
+			this.ShowRGBColorPicker = false
 			removeColorPicker(this, eventsForLaunchpad, guiButtons, commandChannels)
 		}
 
@@ -668,7 +667,7 @@ func ProcessButtons(X int, Y int,
 	}
 
 	// Decrease Shift.
-	if X == 2 && Y == 7 && !this.EditSequenceColorPickerMode {
+	if X == 2 && Y == 7 && !this.ShowRGBColorPicker {
 
 		if debug {
 			fmt.Printf("Decrease Shift\n")
@@ -723,7 +722,7 @@ func ProcessButtons(X int, Y int,
 	}
 
 	// Increase Shift.
-	if X == 3 && Y == 7 && !this.EditSequenceColorPickerMode {
+	if X == 3 && Y == 7 && !this.ShowRGBColorPicker {
 
 		if debug {
 			fmt.Printf("Increase Shift \n")
@@ -777,7 +776,7 @@ func ProcessButtons(X int, Y int,
 	}
 
 	// S E L E C T   S P E E D - Decrease speed of selected sequence.
-	if X == 0 && Y == 7 && !this.EditSequenceColorPickerMode {
+	if X == 0 && Y == 7 && !this.ShowRGBColorPicker {
 
 		if debug {
 			fmt.Printf("Decrease Speed \n")
@@ -855,7 +854,7 @@ func ProcessButtons(X int, Y int,
 	}
 
 	// S E L E C T   S P E E D - Increase speed of selected sequence.
-	if X == 1 && Y == 7 && !this.EditSequenceColorPickerMode {
+	if X == 1 && Y == 7 && !this.ShowRGBColorPicker {
 
 		if debug {
 			fmt.Printf("Increase Speed \n")
@@ -944,7 +943,7 @@ func ProcessButtons(X int, Y int,
 
 		HandleSelect(sequences, this, eventsForLaunchpad, commandChannels, guiButtons)
 
-		this.EditSequenceColorPickerMode = false
+		this.ShowRGBColorPicker = false
 		this.EditGoboSelectionMode = false
 		this.DisplayChaserShortCut = false
 		this.EditWhichStaticSequence = 0
@@ -964,7 +963,7 @@ func ProcessButtons(X int, Y int,
 
 		HandleSelect(sequences, this, eventsForLaunchpad, commandChannels, guiButtons)
 
-		this.EditSequenceColorPickerMode = false
+		this.ShowRGBColorPicker = false
 		this.EditGoboSelectionMode = false
 		this.DisplayChaserShortCut = false
 		this.EditWhichStaticSequence = 1
@@ -984,7 +983,7 @@ func ProcessButtons(X int, Y int,
 
 		HandleSelect(sequences, this, eventsForLaunchpad, commandChannels, guiButtons)
 
-		this.EditSequenceColorPickerMode = false
+		this.ShowRGBColorPicker = false
 		this.EditGoboSelectionMode = false
 		if this.ScannerChaser[this.SelectedSequence] {
 			this.EditWhichStaticSequence = 4
@@ -1009,7 +1008,7 @@ func ProcessButtons(X int, Y int,
 		}
 		common.SendCommandToSequence(this.SelectedSequence, cmd, commandChannels)
 
-		this.EditSequenceColorPickerMode = false
+		this.ShowRGBColorPicker = false
 		this.EditGoboSelectionMode = false
 		this.DisplayChaserShortCut = false
 		this.EditWhichStaticSequence = 3
@@ -1020,8 +1019,8 @@ func ProcessButtons(X int, Y int,
 	// S T A R T - Start sequence.
 	if X == 8 && Y == 5 {
 
-		if this.EditSequenceColorPickerMode {
-			this.EditSequenceColorPickerMode = false
+		if this.ShowRGBColorPicker {
+			this.ShowRGBColorPicker = false
 			removeColorPicker(this, eventsForLaunchpad, guiButtons, commandChannels)
 		}
 
@@ -1167,7 +1166,7 @@ func ProcessButtons(X int, Y int,
 	}
 
 	// Size decrease.
-	if X == 4 && Y == 7 && !this.EditSequenceColorPickerMode {
+	if X == 4 && Y == 7 && !this.ShowRGBColorPicker {
 
 		if debug {
 			fmt.Printf("Decrease Size\n")
@@ -1222,7 +1221,7 @@ func ProcessButtons(X int, Y int,
 	}
 
 	// Increase Size.
-	if X == 5 && Y == 7 && !this.EditSequenceColorPickerMode {
+	if X == 5 && Y == 7 && !this.ShowRGBColorPicker {
 
 		if debug {
 			fmt.Printf("Increase Size\n")
@@ -1278,7 +1277,7 @@ func ProcessButtons(X int, Y int,
 	}
 
 	// Fade time decrease.
-	if X == 6 && Y == 7 && !this.EditSequenceColorPickerMode {
+	if X == 6 && Y == 7 && !this.ShowRGBColorPicker {
 
 		if debug {
 			fmt.Printf("Decrease Fade Time\n")
@@ -1335,7 +1334,7 @@ func ProcessButtons(X int, Y int,
 	}
 
 	// Fade time increase.
-	if X == 7 && Y == 7 && !this.EditSequenceColorPickerMode {
+	if X == 7 && Y == 7 && !this.ShowRGBColorPicker {
 
 		if debug {
 			fmt.Printf("Increase Fade Time\n")
@@ -1399,8 +1398,8 @@ func ProcessButtons(X int, Y int,
 			fmt.Printf("Switch Key X:%d Y:%d\n", X, Y)
 		}
 
-		if this.EditSequenceColorPickerMode {
-			this.EditSequenceColorPickerMode = false
+		if this.ShowRGBColorPicker {
+			this.ShowRGBColorPicker = false
 			removeColorPicker(this, eventsForLaunchpad, guiButtons, commandChannels)
 		}
 
@@ -1637,7 +1636,7 @@ func ProcessButtons(X int, Y int,
 		Y != -1 && Y < 3 &&
 		!this.EditFixtureSelectionMode &&
 		!this.EditScannerColorsMode &&
-		this.EditSequenceColorPickerMode {
+		this.ShowRGBColorPicker {
 
 		if debug {
 			fmt.Printf("Set Sequence Color X:%d Y:%d\n", X, Y)
@@ -1664,7 +1663,7 @@ func ProcessButtons(X int, Y int,
 		}
 		common.SendCommandToSequence(this.TargetSequence, cmd, commandChannels)
 
-		this.EditSequenceColorPickerMode = true
+		this.ShowRGBColorPicker = true
 
 		// Get an upto date copy of the sequence.
 		sequences[this.TargetSequence] = common.RefreshSequence(this.TargetSequence, commandChannels, updateChannels)
@@ -1821,7 +1820,7 @@ func ProcessButtons(X int, Y int,
 		!this.EditFixtureSelectionMode &&
 		this.SelectedSequence == Y && // Make sure the buttons pressed are for this sequence.
 		this.SelectMode[this.SelectedSequence] == NORMAL && // Not in function Mode
-		!this.EditColorPicker && // Not In Color Picker Mode.
+		!this.ShowStaticColorPicker && // Not In Color Picker Mode.
 		this.EditStaticColorsMode[this.EditWhichStaticSequence] { // Static Function On in any sequence
 
 		this.TargetSequence = this.EditWhichStaticSequence
@@ -1856,8 +1855,8 @@ func ProcessButtons(X int, Y int,
 		// We call ShowRGBColorPicker so you can choose the static color for this fixture.
 		ShowRGBColorPicker(this.MasterBrightness, *sequences[this.TargetSequence], this.DisplaySequence, eventsForLaunchpad, guiButtons, commandChannels)
 
-		// Switch the mode so we know we are picking a color from the color picker.
-		this.EditColorPicker = true
+		// Switch the mode so we know we are picking a static color from the color picker.
+		this.ShowStaticColorPicker = true
 
 		return
 	}
@@ -1865,7 +1864,7 @@ func ProcessButtons(X int, Y int,
 	// S E T   S T A T I C   C O L O R
 	if X >= 0 && X < 8 && Y != -1 &&
 		Y < 3 && // Make sure the buttons pressed inside the color picker.
-		this.EditColorPicker && // Now We Are In Color Picker Mode.
+		this.ShowStaticColorPicker && // Now We Are In Color Picker Mode.
 		!this.EditFixtureSelectionMode && // Not In Fixture Selection Mode.
 		this.EditStaticColorsMode[this.EditWhichStaticSequence] { // Static Function On in this sequence
 
@@ -1952,7 +1951,7 @@ func ProcessButtons(X int, Y int,
 		common.RevealSequence(this.TargetSequence, commandChannels)
 
 		// Switch off the color picker.
-		this.EditColorPicker = false
+		this.ShowStaticColorPicker = false
 
 		return
 	}
@@ -1965,9 +1964,6 @@ func ProcessButtons(X int, Y int,
 		if this.SelectMode[this.SelectedSequence] == CHASER_FUNCTION {
 			this.TargetSequence = this.ChaserSequenceNumber
 			this.DisplaySequence = this.SelectedSequence
-			// This is the way we get the shutter chaser to be displayed as we exit
-			// the pattern selection
-			this.DisplayChaserShortCut = true
 			this.SelectMode[this.DisplaySequence] = CHASER_FUNCTION
 		} else {
 			this.TargetSequence = this.SelectedSequence
@@ -2223,7 +2219,7 @@ func ShowScannerColorSelectionButtons(sequence common.Sequence, this *CurrentSta
 	if sequence.ScannerAvailableColors[this.SelectedFixture+1] == nil {
 
 		// Turn off the color edit mode.
-		this.EditSequenceColorPickerMode = false
+		this.ShowRGBColorPicker = false
 		// And since we seem to be using two flags for the same thing, turn this off too.
 		this.Functions[this.SelectedSequence][common.Function5_Color].State = false
 
@@ -2472,7 +2468,7 @@ func clearAllModes(sequences []*common.Sequence, this *CurrentState) {
 	for sequenceNumber := range sequences {
 		this.SelectButtonPressed[sequenceNumber] = false
 		this.SelectMode[sequenceNumber] = NORMAL
-		this.EditSequenceColorPickerMode = false
+		this.ShowRGBColorPicker = false
 		this.EditStaticColorsMode[this.DisplaySequence] = false
 		this.EditStaticColorsMode[this.TargetSequence] = false
 		this.EditGoboSelectionMode = false

--- a/pkg/buttons/buttons.go
+++ b/pkg/buttons/buttons.go
@@ -1825,8 +1825,6 @@ func ProcessButtons(X int, Y int,
 		return
 	}
 
-	printHandleDebug(this)
-
 	// S E L E C T   S T A T I C   F I X T U R E
 	if X >= 0 && X < 8 &&
 		Y != -1 &&

--- a/pkg/buttons/buttons.go
+++ b/pkg/buttons/buttons.go
@@ -81,7 +81,7 @@ type CurrentState struct {
 	FunctionLabels              [8]string                  // Storage for the function key labels for this sequence.
 	SelectButtonPressed         []bool                     // Which sequence has its Select button pressed.
 	SwitchPositions             [9][9]int                  // Sorage for switch positions.
-	EditSequenceColorsMode      bool                       // This flag is true when the sequence is in select sequence chase colors editing mode.
+	EditSequenceColorPickerMode bool                       // This flag is true when the sequence is in when we are using the color picker.
 	EditScannerColorsMode       bool                       // This flag is true when the sequence is in select scanner colors editing mode.
 	EditGoboSelectionMode       bool                       // This flag is true when the sequence is in sequence gobo selection mode.
 	EditStaticColorsMode        []bool                     // This flag is true when the sequence is in static colors editing mode.
@@ -183,7 +183,7 @@ func ProcessButtons(X int, Y int,
 		!this.Functions[Y][common.Function6_Static_Gobo].State &&
 		!this.Functions[Y][common.Function5_Color].State &&
 		!this.EditStaticColorsMode[Y] &&
-		!this.EditSequenceColorsMode &&
+		!this.EditSequenceColorPickerMode &&
 		!this.EditColorPicker &&
 		sequences[Y].Type != "switch" && // As long as we're not a switch sequence.
 		this.SelectMode[Y] == NORMAL { // As long as we're in normal mode for this sequence.
@@ -243,7 +243,7 @@ func ProcessButtons(X int, Y int,
 		!this.Functions[Y][common.Function1_Pattern].State &&
 		!this.Functions[Y][common.Function6_Static_Gobo].State &&
 		!this.Functions[Y][common.Function5_Color].State &&
-		!this.EditSequenceColorsMode &&
+		!this.EditSequenceColorPickerMode &&
 		!this.EditColorPicker &&
 		sequences[Y].Type != "switch" && // As long as we're not a switch sequence.
 		this.SelectMode[Y] == NORMAL { // As long as we're in normal mode for this sequence.
@@ -600,8 +600,8 @@ func ProcessButtons(X int, Y int,
 			fmt.Printf("Ask For Config\n")
 		}
 
-		if this.EditSequenceColorsMode {
-			this.EditSequenceColorsMode = false
+		if this.EditSequenceColorPickerMode {
+			this.EditSequenceColorPickerMode = false
 			removeColorPicker(this, eventsForLaunchpad, guiButtons, commandChannels)
 		}
 
@@ -668,7 +668,7 @@ func ProcessButtons(X int, Y int,
 	}
 
 	// Decrease Shift.
-	if X == 2 && Y == 7 && !this.EditSequenceColorsMode {
+	if X == 2 && Y == 7 && !this.EditSequenceColorPickerMode {
 
 		if debug {
 			fmt.Printf("Decrease Shift\n")
@@ -723,7 +723,7 @@ func ProcessButtons(X int, Y int,
 	}
 
 	// Increase Shift.
-	if X == 3 && Y == 7 && !this.EditSequenceColorsMode {
+	if X == 3 && Y == 7 && !this.EditSequenceColorPickerMode {
 
 		if debug {
 			fmt.Printf("Increase Shift \n")
@@ -777,7 +777,7 @@ func ProcessButtons(X int, Y int,
 	}
 
 	// S E L E C T   S P E E D - Decrease speed of selected sequence.
-	if X == 0 && Y == 7 && !this.EditSequenceColorsMode {
+	if X == 0 && Y == 7 && !this.EditSequenceColorPickerMode {
 
 		if debug {
 			fmt.Printf("Decrease Speed \n")
@@ -855,7 +855,7 @@ func ProcessButtons(X int, Y int,
 	}
 
 	// S E L E C T   S P E E D - Increase speed of selected sequence.
-	if X == 1 && Y == 7 && !this.EditSequenceColorsMode {
+	if X == 1 && Y == 7 && !this.EditSequenceColorPickerMode {
 
 		if debug {
 			fmt.Printf("Increase Speed \n")
@@ -944,7 +944,7 @@ func ProcessButtons(X int, Y int,
 
 		HandleSelect(sequences, this, eventsForLaunchpad, commandChannels, guiButtons)
 
-		this.EditSequenceColorsMode = false
+		this.EditSequenceColorPickerMode = false
 		this.EditGoboSelectionMode = false
 		this.DisplayChaserShortCut = false
 
@@ -963,7 +963,7 @@ func ProcessButtons(X int, Y int,
 
 		HandleSelect(sequences, this, eventsForLaunchpad, commandChannels, guiButtons)
 
-		this.EditSequenceColorsMode = false
+		this.EditSequenceColorPickerMode = false
 		this.EditGoboSelectionMode = false
 		this.DisplayChaserShortCut = false
 
@@ -982,7 +982,7 @@ func ProcessButtons(X int, Y int,
 
 		HandleSelect(sequences, this, eventsForLaunchpad, commandChannels, guiButtons)
 
-		this.EditSequenceColorsMode = false
+		this.EditSequenceColorPickerMode = false
 		this.EditGoboSelectionMode = false
 
 		return
@@ -1004,7 +1004,7 @@ func ProcessButtons(X int, Y int,
 		}
 		common.SendCommandToSequence(this.SelectedSequence, cmd, commandChannels)
 
-		this.EditSequenceColorsMode = false
+		this.EditSequenceColorPickerMode = false
 		this.EditGoboSelectionMode = false
 		this.DisplayChaserShortCut = false
 
@@ -1014,8 +1014,8 @@ func ProcessButtons(X int, Y int,
 	// S T A R T - Start sequence.
 	if X == 8 && Y == 5 {
 
-		if this.EditSequenceColorsMode {
-			this.EditSequenceColorsMode = false
+		if this.EditSequenceColorPickerMode {
+			this.EditSequenceColorPickerMode = false
 			removeColorPicker(this, eventsForLaunchpad, guiButtons, commandChannels)
 		}
 
@@ -1160,7 +1160,7 @@ func ProcessButtons(X int, Y int,
 	}
 
 	// Size decrease.
-	if X == 4 && Y == 7 && !this.EditSequenceColorsMode {
+	if X == 4 && Y == 7 && !this.EditSequenceColorPickerMode {
 
 		if debug {
 			fmt.Printf("Decrease Size\n")
@@ -1215,7 +1215,7 @@ func ProcessButtons(X int, Y int,
 	}
 
 	// Increase Size.
-	if X == 5 && Y == 7 && !this.EditSequenceColorsMode {
+	if X == 5 && Y == 7 && !this.EditSequenceColorPickerMode {
 
 		if debug {
 			fmt.Printf("Increase Size\n")
@@ -1271,7 +1271,7 @@ func ProcessButtons(X int, Y int,
 	}
 
 	// Fade time decrease.
-	if X == 6 && Y == 7 && !this.EditSequenceColorsMode {
+	if X == 6 && Y == 7 && !this.EditSequenceColorPickerMode {
 
 		if debug {
 			fmt.Printf("Decrease Fade Time\n")
@@ -1328,7 +1328,7 @@ func ProcessButtons(X int, Y int,
 	}
 
 	// Fade time increase.
-	if X == 7 && Y == 7 && !this.EditSequenceColorsMode {
+	if X == 7 && Y == 7 && !this.EditSequenceColorPickerMode {
 
 		if debug {
 			fmt.Printf("Increase Fade Time\n")
@@ -1392,8 +1392,8 @@ func ProcessButtons(X int, Y int,
 			fmt.Printf("Switch Key X:%d Y:%d\n", X, Y)
 		}
 
-		if this.EditSequenceColorsMode {
-			this.EditSequenceColorsMode = false
+		if this.EditSequenceColorPickerMode {
+			this.EditSequenceColorPickerMode = false
 			removeColorPicker(this, eventsForLaunchpad, guiButtons, commandChannels)
 		}
 
@@ -1630,7 +1630,7 @@ func ProcessButtons(X int, Y int,
 		Y != -1 && Y < 3 &&
 		!this.EditFixtureSelectionMode &&
 		!this.EditScannerColorsMode &&
-		this.EditSequenceColorsMode {
+		this.EditSequenceColorPickerMode {
 
 		if debug {
 			fmt.Printf("Set Sequence Color X:%d Y:%d\n", X, Y)
@@ -1657,7 +1657,7 @@ func ProcessButtons(X int, Y int,
 		}
 		common.SendCommandToSequence(this.TargetSequence, cmd, commandChannels)
 
-		this.EditSequenceColorsMode = true
+		this.EditSequenceColorPickerMode = true
 
 		// Get an upto date copy of the sequence.
 		sequences[this.TargetSequence] = common.RefreshSequence(this.TargetSequence, commandChannels, updateChannels)
@@ -1820,6 +1820,12 @@ func ProcessButtons(X int, Y int,
 		this.TargetSequence = this.EditWhichSequence
 		this.DisplaySequence = this.SelectedSequence
 
+		if debug {
+			fmt.Printf("EditWhichSequence %d\n", this.EditWhichSequence)
+			fmt.Printf("TargetSequence %d\n", this.TargetSequence)
+			fmt.Printf("DisplaySequence %d\n", this.DisplaySequence)
+		}
+
 		// Save the selected fixture number.
 		this.SelectedStaticFixtureNumber = X
 
@@ -1855,6 +1861,15 @@ func ProcessButtons(X int, Y int,
 		this.EditColorPicker && // Now We Are In Color Picker Mode.
 		!this.EditFixtureSelectionMode && // Not In Fixture Selection Mode.
 		this.EditStaticColorsMode[this.EditWhichSequence] { // Static Function On in this sequence
+
+		this.TargetSequence = this.EditWhichSequence
+		this.DisplaySequence = this.SelectedSequence
+
+		if debug {
+			fmt.Printf("EditWhichSequence %d\n", this.EditWhichSequence)
+			fmt.Printf("TargetSequence %d\n", this.TargetSequence)
+			fmt.Printf("DisplaySequence %d\n", this.DisplaySequence)
+		}
 
 		// Find the color from the button pressed.
 		color := FindCurrentColor(X, Y, *sequences[this.TargetSequence])
@@ -2201,7 +2216,7 @@ func ShowScannerColorSelectionButtons(sequence common.Sequence, this *CurrentSta
 	if sequence.ScannerAvailableColors[this.SelectedFixture+1] == nil {
 
 		// Turn off the color edit mode.
-		this.EditSequenceColorsMode = false
+		this.EditSequenceColorPickerMode = false
 		// And since we seem to be using two flags for the same thing, turn this off too.
 		this.Functions[this.SelectedSequence][common.Function5_Color].State = false
 
@@ -2450,7 +2465,7 @@ func clearAllModes(sequences []*common.Sequence, this *CurrentState) {
 	for sequenceNumber := range sequences {
 		this.SelectButtonPressed[sequenceNumber] = false
 		this.SelectMode[sequenceNumber] = NORMAL
-		this.EditSequenceColorsMode = false
+		this.EditSequenceColorPickerMode = false
 		this.EditStaticColorsMode[this.DisplaySequence] = false
 		this.EditStaticColorsMode[this.TargetSequence] = false
 		this.EditGoboSelectionMode = false

--- a/pkg/buttons/buttons.go
+++ b/pkg/buttons/buttons.go
@@ -1048,6 +1048,7 @@ func ProcessButtons(X int, Y int,
 			common.SendCommandToSequence(this.SelectedSequence, cmd, commandChannels)
 
 			this.Running[this.SelectedSequence] = false
+			this.Functions[this.SelectedSequence][common.Function6_Static_Gobo].State = false
 			this.Functions[this.SelectedSequence][common.Function8_Music_Trigger].State = false
 
 			// Stop should also stop the shutter chaser.
@@ -1082,8 +1083,6 @@ func ProcessButtons(X int, Y int,
 				fmt.Printf("Start Sequence %d \n", Y)
 			}
 
-			this.Functions[this.SelectedSequence][common.Function6_Static_Gobo].State = false
-
 			sequences[this.SelectedSequence].MusicTrigger = false
 			cmd := common.Command{
 				Action: common.Start,
@@ -1093,7 +1092,10 @@ func ProcessButtons(X int, Y int,
 			}
 			common.SendCommandToSequence(this.SelectedSequence, cmd, commandChannels)
 			common.LightLamp(common.ALight{X: X, Y: Y, Brightness: this.MasterBrightness, Red: 0, Green: 255, Blue: 0}, eventsForLaunchpad, guiButtons)
+
 			this.Running[this.SelectedSequence] = true
+			this.Functions[this.SelectedSequence][common.Function6_Static_Gobo].State = false
+			this.Functions[this.SelectedSequence][common.Function8_Music_Trigger].State = false
 
 			// Clear the pattern function keys
 			common.ClearSelectedRowOfButtons(this.SelectedSequence, eventsForLaunchpad, guiButtons)
@@ -2510,6 +2512,11 @@ func printMode(sequencNumber int) string {
 }
 
 func SequenceSelect(eventsForLauchpad chan common.ALight, guiButtons chan common.ALight, this *CurrentState) {
+
+	if debug {
+		fmt.Printf("SequenceSelect\n")
+	}
+
 	// Turn off all sequence lights.
 	for seq := 0; seq < 3; seq++ {
 		common.LightLamp(common.ALight{X: 8, Y: seq, Brightness: 255, Red: 100, Green: 255, Blue: 255}, eventsForLauchpad, guiButtons)

--- a/pkg/buttons/buttons.go
+++ b/pkg/buttons/buttons.go
@@ -29,7 +29,6 @@ import (
 	"github.com/dhowlett99/dmxlights/pkg/fixture"
 	"github.com/dhowlett99/dmxlights/pkg/pad"
 	"github.com/dhowlett99/dmxlights/pkg/presets"
-	"github.com/dhowlett99/dmxlights/pkg/sequence"
 	"github.com/dhowlett99/dmxlights/pkg/sound"
 	"github.com/oliread/usbdmx"
 	"github.com/oliread/usbdmx/ft232"
@@ -49,7 +48,7 @@ const (
 type CurrentState struct {
 	MyWindow                    fyne.Window                // Pointer to main window.
 	GUI                         bool                       // Flag to indicate use of GUI.
-	Crash1                      bool                       // Flags to detect launchpad crash.
+	Crash1                      bool                       // Flags to detect launpad crash.
 	Crash2                      bool                       // Flags to detect launchpad crash.
 	SelectedSequence            int                        // The currently selected sequence.
 	TargetSequence              int                        // The current target sequence.
@@ -2320,7 +2319,7 @@ func InitButtons(this *CurrentState, eventsForLaunchpad chan common.ALight, guiB
 
 	// Light the first sequence as the default selected.
 	this.SelectedSequence = 0
-	sequence.SequenceSelect(eventsForLaunchpad, guiButtons, this.SelectedSequence)
+	SequenceSelect(eventsForLaunchpad, guiButtons, this)
 
 }
 
@@ -2449,4 +2448,21 @@ func printMode(this *CurrentState) {
 	if this.SelectMode[this.DisplaySequence] == STATUS {
 		fmt.Printf("PrintMode: this.SelectMode[%d] = STATUS \n", this.SelectedSequence)
 	}
+}
+
+func SequenceSelect(eventsForLauchpad chan common.ALight, guiButtons chan common.ALight, this *CurrentState) {
+	// Turn off all sequence lights.
+	for seq := 0; seq < 3; seq++ {
+		common.LightLamp(common.ALight{X: 8, Y: seq, Brightness: 255, Red: 100, Green: 255, Blue: 255}, eventsForLauchpad, guiButtons)
+	}
+
+	if this.SelectedType == "scanner" && this.ScannerChaser[this.SelectedSequence] &&
+		(this.SelectMode[this.SelectedSequence] == CHASER_FUNCTION || this.SelectMode[this.SelectedSequence] == CHASER_DISPLAY) {
+		// If we are in shutter chaser mode, light the lamp yellow.
+		common.LightLamp(common.ALight{X: 8, Y: this.SelectedSequence, Brightness: 255, Red: 255, Green: 255, Blue: 0}, eventsForLauchpad, guiButtons)
+	} else {
+		// Now turn pink the selected sequence select light.
+		common.LightLamp(common.ALight{X: 8, Y: this.SelectedSequence, Brightness: 255, Red: 255, Green: 0, Blue: 255}, eventsForLauchpad, guiButtons)
+	}
+
 }

--- a/pkg/buttons/buttons.go
+++ b/pkg/buttons/buttons.go
@@ -1080,6 +1080,9 @@ func ProcessButtons(X int, Y int,
 			if debug {
 				fmt.Printf("Start Sequence %d \n", Y)
 			}
+
+			this.Functions[this.SelectedSequence][common.Function6_Static_Gobo].State = false
+
 			sequences[this.SelectedSequence].MusicTrigger = false
 			cmd := common.Command{
 				Action: common.Start,

--- a/pkg/buttons/buttons.go
+++ b/pkg/buttons/buttons.go
@@ -1666,7 +1666,7 @@ func ProcessButtons(X int, Y int,
 		sequences[this.TargetSequence].CurrentColors = sequences[this.TargetSequence].SequenceColors
 
 		// We call ShowRGBColorPicker here so the selections will flash as you press them.
-		ShowRGBColorPicker(this.MasterBrightness, *sequences[this.TargetSequence], this.DisplaySequence, eventsForLaunchpad, guiButtons)
+		ShowRGBColorPicker(this.MasterBrightness, *sequences[this.TargetSequence], this.DisplaySequence, eventsForLaunchpad, guiButtons, commandChannels)
 
 		return
 	}
@@ -1841,7 +1841,7 @@ func ProcessButtons(X int, Y int,
 		sequences[this.TargetSequence].CurrentColors = SetRGBColorPicker(color, *sequences[this.TargetSequence])
 
 		// We call ShowRGBColorPicker so you can choose the static color for this fixture.
-		ShowRGBColorPicker(this.MasterBrightness, *sequences[this.TargetSequence], this.DisplaySequence, eventsForLaunchpad, guiButtons)
+		ShowRGBColorPicker(this.MasterBrightness, *sequences[this.TargetSequence], this.DisplaySequence, eventsForLaunchpad, guiButtons, commandChannels)
 
 		// Switch the mode so we know we are picking a color from the color picker.
 		this.EditColorPicker = true
@@ -1908,7 +1908,7 @@ func ProcessButtons(X int, Y int,
 		this.LastStaticColorButtonY = Y
 
 		// We call ShowRGBColorPicker so you can see which static color has been selected for this fixture.
-		ShowRGBColorPicker(this.MasterBrightness, *sequences[this.TargetSequence], this.DisplaySequence, eventsForLaunchpad, guiButtons)
+		ShowRGBColorPicker(this.MasterBrightness, *sequences[this.TargetSequence], this.DisplaySequence, eventsForLaunchpad, guiButtons, commandChannels)
 
 		// Set the first pressed for only this fixture and cancel any others
 		for x := 0; x < 8; x++ {
@@ -2088,11 +2088,15 @@ func FindCurrentColor(X int, Y int, targetSequence common.Sequence) common.Color
 // ShowRGBColorPicker operates on the sequence.RGBAvailableColors which is an array of type []common.StaticColorButton
 // the targetSequence .CurrentColors selects which colors are selected.
 // Returns the RGBAvailableColors []common.StaticColorButton
-func ShowRGBColorPicker(master int, targetSequence common.Sequence, displaySequence int, eventsForLaunchpad chan common.ALight, guiButtons chan common.ALight) {
+func ShowRGBColorPicker(master int, targetSequence common.Sequence, displaySequence int, eventsForLaunchpad chan common.ALight, guiButtons chan common.ALight, commandChannels []chan common.Command) {
 
 	if debug {
 		fmt.Printf("Color Picker - Show Color Selection Buttons\n")
 	}
+
+	common.HideSequence(0, commandChannels)
+	common.HideSequence(1, commandChannels)
+	common.HideSequence(1, commandChannels)
 
 	for myFixtureNumber, lamp := range targetSequence.RGBAvailableColors {
 

--- a/pkg/buttons/buttons.go
+++ b/pkg/buttons/buttons.go
@@ -700,7 +700,7 @@ func ProcessButtons(X int, Y int,
 			common.SendCommandToSequence(this.TargetSequence, cmd, commandChannels)
 
 			// Update the status bar
-			UpdateShift(this.TargetSequence, this.SelectMode[this.DisplaySequence], this.RGBShift[this.TargetSequence], this.SelectedType, guiButtons)
+			UpdateShift(this, guiButtons)
 			return
 		}
 
@@ -754,7 +754,7 @@ func ProcessButtons(X int, Y int,
 			common.SendCommandToSequence(this.TargetSequence, cmd, commandChannels)
 
 			// Update the status bar
-			UpdateShift(this.TargetSequence, this.SelectMode[this.DisplaySequence], this.RGBShift[this.TargetSequence], this.SelectedType, guiButtons)
+			UpdateShift(this, guiButtons)
 			return
 		}
 
@@ -851,7 +851,7 @@ func ProcessButtons(X int, Y int,
 		}
 
 		// Update the status bar
-		UpdateSpeed(this.TargetSequence, this.SelectMode[this.DisplaySequence], this.Speed[this.TargetSequence], this.SelectedType, guiButtons)
+		UpdateSpeed(this, guiButtons)
 
 		return
 	}
@@ -928,7 +928,7 @@ func ProcessButtons(X int, Y int,
 		}
 
 		// Update the status bar
-		UpdateSpeed(this.TargetSequence, this.SelectMode[this.DisplaySequence], this.Speed[this.TargetSequence], this.SelectedType, guiButtons)
+		UpdateSpeed(this, guiButtons)
 
 		return
 	}
@@ -1199,7 +1199,7 @@ func ProcessButtons(X int, Y int,
 			}
 			common.SendCommandToSequence(this.TargetSequence, cmd, commandChannels)
 			// Update the status bar
-			UpdateSize(this.TargetSequence, this.SelectMode[this.DisplaySequence], this.RGBSize[this.TargetSequence], this.SelectedType, guiButtons)
+			UpdateSize(this, guiButtons)
 			return
 		}
 
@@ -1254,7 +1254,7 @@ func ProcessButtons(X int, Y int,
 			}
 			common.SendCommandToSequence(this.TargetSequence, cmd, commandChannels)
 			// Update the status bar
-			UpdateSize(this.TargetSequence, this.SelectMode[this.DisplaySequence], this.RGBSize[this.TargetSequence], this.SelectedType, guiButtons)
+			UpdateSize(this, guiButtons)
 			return
 		}
 
@@ -1308,7 +1308,7 @@ func ProcessButtons(X int, Y int,
 			}
 			common.SendCommandToSequence(this.TargetSequence, cmd, commandChannels)
 			// Update the status bar
-			UpdateFade(this.TargetSequence, this.SelectMode[this.DisplaySequence], this.RGBFade[this.TargetSequence], this.SelectedType, guiButtons)
+			UpdateFade(this, guiButtons)
 			return
 		}
 
@@ -1364,7 +1364,7 @@ func ProcessButtons(X int, Y int,
 			}
 			common.SendCommandToSequence(this.TargetSequence, cmd, commandChannels)
 			// Update the status bar
-			UpdateFade(this.TargetSequence, this.SelectMode[this.DisplaySequence], this.RGBFade[this.TargetSequence], this.SelectedType, guiButtons)
+			UpdateFade(this, guiButtons)
 			return
 		}
 
@@ -2518,7 +2518,11 @@ func SequenceSelect(eventsForLauchpad chan common.ALight, guiButtons chan common
 
 }
 
-func UpdateSpeed(sequenceNumber int, mode int, speed int, tYpe string, guiButttons chan common.ALight) {
+func UpdateSpeed(this *CurrentState, guiButttons chan common.ALight) {
+
+	mode := this.SelectMode[this.TargetSequence]
+	tYpe := this.SelectedType
+	speed := this.Speed[this.TargetSequence]
 
 	if mode == NORMAL || mode == FUNCTION || mode == STATUS {
 		if tYpe == "rgb" {
@@ -2533,7 +2537,11 @@ func UpdateSpeed(sequenceNumber int, mode int, speed int, tYpe string, guiButtto
 	}
 }
 
-func UpdateSize(sequenceNumber int, mode int, size int, tYpe string, guiButttons chan common.ALight) {
+func UpdateSize(this *CurrentState, guiButttons chan common.ALight) {
+
+	mode := this.SelectMode[this.TargetSequence]
+	tYpe := this.SelectedType
+	size := this.RGBSize[this.TargetSequence]
 
 	if mode == NORMAL || mode == FUNCTION || mode == STATUS {
 		if tYpe == "rgb" {
@@ -2548,7 +2556,11 @@ func UpdateSize(sequenceNumber int, mode int, size int, tYpe string, guiButttons
 	}
 }
 
-func UpdateShift(sequenceNumber int, mode int, shift int, tYpe string, guiButttons chan common.ALight) {
+func UpdateShift(this *CurrentState, guiButttons chan common.ALight) {
+
+	mode := this.SelectMode[this.TargetSequence]
+	tYpe := this.SelectedType
+	shift := this.RGBShift[this.TargetSequence]
 
 	if mode == NORMAL || mode == FUNCTION || mode == STATUS {
 		if tYpe == "rgb" {
@@ -2563,7 +2575,11 @@ func UpdateShift(sequenceNumber int, mode int, shift int, tYpe string, guiButtto
 	}
 }
 
-func UpdateFade(sequenceNumber int, mode int, fade int, tYpe string, guiButttons chan common.ALight) {
+func UpdateFade(this *CurrentState, guiButttons chan common.ALight) {
+
+	mode := this.SelectMode[this.TargetSequence]
+	tYpe := this.SelectedType
+	fade := this.RGBFade[this.TargetSequence]
 
 	if mode == NORMAL || mode == FUNCTION || mode == STATUS {
 		if tYpe == "rgb" {

--- a/pkg/buttons/buttons.go
+++ b/pkg/buttons/buttons.go
@@ -947,6 +947,7 @@ func ProcessButtons(X int, Y int,
 		this.EditSequenceColorPickerMode = false
 		this.EditGoboSelectionMode = false
 		this.DisplayChaserShortCut = false
+		this.EditWhichSequence = 0
 
 		return
 	}
@@ -966,6 +967,7 @@ func ProcessButtons(X int, Y int,
 		this.EditSequenceColorPickerMode = false
 		this.EditGoboSelectionMode = false
 		this.DisplayChaserShortCut = false
+		this.EditWhichSequence = 1
 
 		return
 	}
@@ -984,6 +986,7 @@ func ProcessButtons(X int, Y int,
 
 		this.EditSequenceColorPickerMode = false
 		this.EditGoboSelectionMode = false
+		this.EditWhichSequence = 2
 
 		return
 	}
@@ -1007,6 +1010,7 @@ func ProcessButtons(X int, Y int,
 		this.EditSequenceColorPickerMode = false
 		this.EditGoboSelectionMode = false
 		this.DisplayChaserShortCut = false
+		this.EditWhichSequence = 3
 
 		return
 	}

--- a/pkg/buttons/buttons.go
+++ b/pkg/buttons/buttons.go
@@ -55,6 +55,7 @@ type CurrentState struct {
 	SelectedSequence            int                        // The currently selected sequence.
 	TargetSequence              int                        // The current target sequence.
 	DisplaySequence             int                        // The current display sequence.
+	SequenceType                []string                   // The type, indexed by sequence.
 	SelectedStaticFixtureNumber int                        // Temporary storage for the selected fixture number, used by color picker.
 	SelectAllStaticFixtures     bool                       // Flag that indicate that all static fixtures have been selected.
 	StaticFlashing              []bool                     // Static buttons are flashing, indexed by sequence.

--- a/pkg/buttons/buttons.go
+++ b/pkg/buttons/buttons.go
@@ -117,7 +117,7 @@ type CurrentState struct {
 	DmxInterfacePresent         bool                       // Flag to indicate precence of DMX interface card
 	DmxInterfacePresentConfig   *usbdmx.ControllerConfig   // DMX Interface card config.
 	LaunchpadName               string                     // Storage for launchpad config.
-	ScannerChaser               bool                       // Chaser is running.
+	ScannerChaser               map[int]bool               // Chaser is running.
 	DisplayChaserShortCut       bool                       // Flag to indicate we've taken a shortcut to the chaser display
 	SwitchSequenceNumber        int                        // Switch sequence number, setup at start.
 	ChaserSequenceNumber        int                        // Chaser sequence number, setup at start.
@@ -678,7 +678,7 @@ func ProcessButtons(X int, Y int,
 		buttonTouched(common.ALight{X: X, Y: Y, OnColor: common.White, OffColor: common.Cyan}, eventsForLaunchpad, guiButtons)
 
 		// If we're a scanner and we're in shutter chase mode.
-		if sequences[this.SelectedSequence].Type == "scanner" && this.ScannerChaser &&
+		if sequences[this.SelectedSequence].Type == "scanner" && this.ScannerChaser[this.SelectedSequence] &&
 			(this.SelectMode[this.SelectedSequence] == CHASER_FUNCTION || this.SelectMode[this.SelectedSequence] == CHASER_DISPLAY) {
 			this.TargetSequence = this.ChaserSequenceNumber
 		} else {
@@ -733,7 +733,7 @@ func ProcessButtons(X int, Y int,
 		buttonTouched(common.ALight{X: X, Y: Y, OnColor: common.White, OffColor: common.Cyan}, eventsForLaunchpad, guiButtons)
 
 		// If we're a scanner and we're in shutter chase mode.
-		if sequences[this.SelectedSequence].Type == "scanner" && this.ScannerChaser &&
+		if sequences[this.SelectedSequence].Type == "scanner" && this.ScannerChaser[this.SelectedSequence] &&
 			(this.SelectMode[this.SelectedSequence] == CHASER_FUNCTION || this.SelectMode[this.SelectedSequence] == CHASER_DISPLAY) {
 			this.TargetSequence = this.ChaserSequenceNumber
 		} else {
@@ -787,7 +787,7 @@ func ProcessButtons(X int, Y int,
 		buttonTouched(common.ALight{X: X, Y: Y, OnColor: common.White, OffColor: common.Cyan}, eventsForLaunchpad, guiButtons)
 
 		// If we're a scanner and we're in shutter chase mode.
-		if sequences[this.SelectedSequence].Type == "scanner" && this.ScannerChaser &&
+		if sequences[this.SelectedSequence].Type == "scanner" && this.ScannerChaser[this.SelectedSequence] &&
 			(this.SelectMode[this.SelectedSequence] == CHASER_FUNCTION || this.SelectMode[this.SelectedSequence] == CHASER_DISPLAY) {
 			this.TargetSequence = this.ChaserSequenceNumber
 		} else {
@@ -865,7 +865,7 @@ func ProcessButtons(X int, Y int,
 		buttonTouched(common.ALight{X: X, Y: Y, OnColor: common.White, OffColor: common.Cyan}, eventsForLaunchpad, guiButtons)
 
 		// If we're a scanner and we're in shutter chase mode
-		if sequences[this.SelectedSequence].Type == "scanner" && this.ScannerChaser &&
+		if sequences[this.SelectedSequence].Type == "scanner" && this.ScannerChaser[this.SelectedSequence] &&
 			(this.SelectMode[this.SelectedSequence] == CHASER_FUNCTION || this.SelectMode[this.SelectedSequence] == CHASER_DISPLAY) {
 			this.TargetSequence = this.ChaserSequenceNumber
 		} else {
@@ -1017,7 +1017,7 @@ func ProcessButtons(X int, Y int,
 			removeColorPicker(this, eventsForLaunchpad, guiButtons, commandChannels)
 		}
 
-		if this.ScannerChaser {
+		if this.ScannerChaser[this.SelectedSequence] {
 			common.HideSequence(this.ChaserSequenceNumber, commandChannels)
 			common.ClearSelectedRowOfButtons(this.SelectedSequence, eventsForLaunchpad, guiButtons)
 			this.SelectMode[this.SelectedSequence] = NORMAL
@@ -1139,7 +1139,7 @@ func ProcessButtons(X int, Y int,
 		buttonTouched(common.ALight{X: X, Y: Y, OnColor: common.White, OffColor: common.Cyan}, eventsForLaunchpad, guiButtons)
 
 		// If we're a scanner and we're in shutter chase mode.
-		if sequences[this.SelectedSequence].Type == "scanner" && this.ScannerChaser &&
+		if sequences[this.SelectedSequence].Type == "scanner" && this.ScannerChaser[this.SelectedSequence] &&
 			(this.SelectMode[this.SelectedSequence] == CHASER_FUNCTION || this.SelectMode[this.SelectedSequence] == CHASER_DISPLAY) {
 			this.TargetSequence = this.ChaserSequenceNumber
 		} else {
@@ -1194,7 +1194,7 @@ func ProcessButtons(X int, Y int,
 		buttonTouched(common.ALight{X: X, Y: Y, OnColor: common.White, OffColor: common.Cyan}, eventsForLaunchpad, guiButtons)
 
 		// If we're a scanner and we're in shutter chase mode.
-		if sequences[this.SelectedSequence].Type == "scanner" && this.ScannerChaser &&
+		if sequences[this.SelectedSequence].Type == "scanner" && this.ScannerChaser[this.SelectedSequence] &&
 			(this.SelectMode[this.SelectedSequence] == CHASER_FUNCTION || this.SelectMode[this.SelectedSequence] == CHASER_DISPLAY) {
 			this.TargetSequence = this.ChaserSequenceNumber
 		} else {
@@ -1250,7 +1250,7 @@ func ProcessButtons(X int, Y int,
 		buttonTouched(common.ALight{X: X, Y: Y, OnColor: common.White, OffColor: common.Cyan}, eventsForLaunchpad, guiButtons)
 
 		// If we're a scanner and we're in shutter chase mode.
-		if sequences[this.SelectedSequence].Type == "scanner" && this.ScannerChaser &&
+		if sequences[this.SelectedSequence].Type == "scanner" && this.ScannerChaser[this.SelectedSequence] &&
 			(this.SelectMode[this.SelectedSequence] == CHASER_FUNCTION || this.SelectMode[this.SelectedSequence] == CHASER_DISPLAY) {
 			this.TargetSequence = this.ChaserSequenceNumber
 		} else {
@@ -1307,7 +1307,7 @@ func ProcessButtons(X int, Y int,
 		buttonTouched(common.ALight{X: X, Y: Y, OnColor: common.White, OffColor: common.Cyan}, eventsForLaunchpad, guiButtons)
 
 		// If we're a scanner and we're in shutter chase mode.
-		if sequences[this.SelectedSequence].Type == "scanner" && this.ScannerChaser &&
+		if sequences[this.SelectedSequence].Type == "scanner" && this.ScannerChaser[this.SelectedSequence] &&
 			(this.SelectMode[this.SelectedSequence] == CHASER_FUNCTION || this.SelectMode[this.SelectedSequence] == CHASER_DISPLAY) {
 			this.TargetSequence = this.ChaserSequenceNumber
 		} else {
@@ -1665,7 +1665,7 @@ func ProcessButtons(X int, Y int,
 		common.SendCommandToSequence(this.SelectedSequence, cmd, commandChannels)
 
 		// If configured set scanner color in chaser.
-		if this.ScannerChaser && this.SelectedType == "scanner" {
+		if this.ScannerChaser[this.SelectedSequence] && this.SelectedType == "scanner" {
 			cmd := common.Command{
 				Action: common.UpdateScannerColor,
 				Args: []common.Arg{
@@ -1750,7 +1750,7 @@ func ProcessButtons(X int, Y int,
 		common.SendCommandToSequence(this.SelectedSequence, cmd, commandChannels)
 
 		// If configured set scanner color in chaser.
-		if this.ScannerChaser && this.SelectedType == "scanner" {
+		if this.ScannerChaser[this.SelectedSequence] && this.SelectedType == "scanner" {
 			cmd := common.Command{
 				Action: common.UpdateGobo,
 				Args: []common.Arg{

--- a/pkg/buttons/buttons.go
+++ b/pkg/buttons/buttons.go
@@ -57,7 +57,7 @@ type CurrentState struct {
 	DisplaySequence             int                        // The current display sequence.
 	SelectedStaticFixtureNumber int                        // Temporary storage for the selected fixture number, used by color picker.
 	SelectAllStaticFixtures     bool                       // Flag that indicate that all static fixtures have been selected.
-	StaticFlashing              bool                       // Static buttons are flashing.
+	StaticFlashing              []bool                     // Static buttons are flashing, indexed by sequence.
 	SavedSequenceColors         map[int][]common.Color     // Local storage for sequence colors.
 	SelectedType                string                     // The currently selected sequenece type.
 	LastSelectedSequence        int                        // Store fof the last selected squence.
@@ -1038,7 +1038,7 @@ func ProcessButtons(X int, Y int,
 			this.SelectMode[this.SelectedSequence] = NORMAL
 		}
 
-		this.StaticFlashing = false
+		this.StaticFlashing[this.SelectedSequence] = false
 
 		// S T O P - If sequence is running, stop it
 		if this.Running[this.SelectedSequence] {

--- a/pkg/buttons/buttons.go
+++ b/pkg/buttons/buttons.go
@@ -1878,7 +1878,7 @@ func ProcessButtons(X int, Y int,
 
 		// Switch the mode so we know we are picking a static color from the color picker.
 		this.ShowStaticColorPicker = true
-		this.EditStaticColorsMode[this.SelectedSequence] = true
+		this.EditStaticColorsMode[this.TargetSequence] = true
 
 		return
 	}

--- a/pkg/buttons/buttons.go
+++ b/pkg/buttons/buttons.go
@@ -86,7 +86,7 @@ type CurrentState struct {
 	EditGoboSelectionMode       bool                       // This flag is true when the sequence is in sequence gobo selection mode.
 	EditStaticColorsMode        []bool                     // This flag is true when the sequence is in static colors editing mode.
 	EditColorPicker             bool                       // This flag is true when the sequence is in color picker mode.
-	EditWhichSequence           int                        // Which sequence is currently being edited.
+	EditWhichStaticSequence     int                        // Which static sequence is currently being edited.
 	EditPatternMode             bool                       // This flag is true when the sequence is in pattern editing mode.
 	EditFixtureSelectionMode    bool                       // This flag is true when the sequence is in select fixture mode.
 	MasterBrightness            int                        // Affects all DMX fixtures and launchpad lamps.
@@ -947,7 +947,7 @@ func ProcessButtons(X int, Y int,
 		this.EditSequenceColorPickerMode = false
 		this.EditGoboSelectionMode = false
 		this.DisplayChaserShortCut = false
-		this.EditWhichSequence = 0
+		this.EditWhichStaticSequence = 0
 
 		return
 	}
@@ -967,7 +967,7 @@ func ProcessButtons(X int, Y int,
 		this.EditSequenceColorPickerMode = false
 		this.EditGoboSelectionMode = false
 		this.DisplayChaserShortCut = false
-		this.EditWhichSequence = 1
+		this.EditWhichStaticSequence = 1
 
 		return
 	}
@@ -986,7 +986,9 @@ func ProcessButtons(X int, Y int,
 
 		this.EditSequenceColorPickerMode = false
 		this.EditGoboSelectionMode = false
-		this.EditWhichSequence = 2
+		if this.ScannerChaser[this.SelectedSequence] {
+			this.EditWhichStaticSequence = 4
+		}
 
 		return
 	}
@@ -1010,7 +1012,7 @@ func ProcessButtons(X int, Y int,
 		this.EditSequenceColorPickerMode = false
 		this.EditGoboSelectionMode = false
 		this.DisplayChaserShortCut = false
-		this.EditWhichSequence = 3
+		this.EditWhichStaticSequence = 3
 
 		return
 	}
@@ -1056,6 +1058,7 @@ func ProcessButtons(X int, Y int,
 				}
 				common.SendCommandToSequence(this.ChaserSequenceNumber, cmd, commandChannels)
 
+				this.Functions[this.SelectedSequence][common.Function6_Static_Gobo].State = false
 				this.Functions[this.SelectedSequence][common.Function7_Invert_Chase].State = false
 				this.ScannerChaser[this.SelectedSequence] = false
 				this.SelectMode[this.SelectedSequence] = NORMAL
@@ -1819,13 +1822,13 @@ func ProcessButtons(X int, Y int,
 		this.SelectedSequence == Y && // Make sure the buttons pressed are for this sequence.
 		this.SelectMode[this.SelectedSequence] == NORMAL && // Not in function Mode
 		!this.EditColorPicker && // Not In Color Picker Mode.
-		this.EditStaticColorsMode[this.EditWhichSequence] { // Static Function On in any sequence
+		this.EditStaticColorsMode[this.EditWhichStaticSequence] { // Static Function On in any sequence
 
-		this.TargetSequence = this.EditWhichSequence
+		this.TargetSequence = this.EditWhichStaticSequence
 		this.DisplaySequence = this.SelectedSequence
 
 		if debug {
-			fmt.Printf("EditWhichSequence %d\n", this.EditWhichSequence)
+			fmt.Printf("EditWhichStaticSequence %d\n", this.EditWhichStaticSequence)
 			fmt.Printf("TargetSequence %d\n", this.TargetSequence)
 			fmt.Printf("DisplaySequence %d\n", this.DisplaySequence)
 		}
@@ -1864,16 +1867,16 @@ func ProcessButtons(X int, Y int,
 		Y < 3 && // Make sure the buttons pressed inside the color picker.
 		this.EditColorPicker && // Now We Are In Color Picker Mode.
 		!this.EditFixtureSelectionMode && // Not In Fixture Selection Mode.
-		this.EditStaticColorsMode[this.EditWhichSequence] { // Static Function On in this sequence
+		this.EditStaticColorsMode[this.EditWhichStaticSequence] { // Static Function On in this sequence
 
-		this.TargetSequence = this.EditWhichSequence
+		this.TargetSequence = this.EditWhichStaticSequence
 		this.DisplaySequence = this.SelectedSequence
 
-		if debug {
-			fmt.Printf("EditWhichSequence %d\n", this.EditWhichSequence)
-			fmt.Printf("TargetSequence %d\n", this.TargetSequence)
-			fmt.Printf("DisplaySequence %d\n", this.DisplaySequence)
-		}
+		//if debug {
+		fmt.Printf("EditWhichStaticSequence %d\n", this.EditWhichStaticSequence)
+		fmt.Printf("TargetSequence %d\n", this.TargetSequence)
+		fmt.Printf("DisplaySequence %d\n", this.DisplaySequence)
+		//}
 
 		// Find the color from the button pressed.
 		color := FindCurrentColor(X, Y, *sequences[this.TargetSequence])

--- a/pkg/buttons/buttons.go
+++ b/pkg/buttons/buttons.go
@@ -118,6 +118,7 @@ type CurrentState struct {
 	DmxInterfacePresentConfig   *usbdmx.ControllerConfig   // DMX Interface card config.
 	LaunchpadName               string                     // Storage for launchpad config.
 	ScannerChaser               bool                       // Chaser is running.
+	DisplayChaserShortCut       bool                       // Flag to indicate we've taken a shortcut to the chaser display
 	SwitchSequenceNumber        int                        // Switch sequence number, setup at start.
 	ChaserSequenceNumber        int                        // Chaser sequence number, setup at start.
 	ScannerSequenceNumber       int                        // Scanner sequence number, setup at start.
@@ -1014,6 +1015,12 @@ func ProcessButtons(X int, Y int,
 		if this.EditSequenceColorsMode {
 			this.EditSequenceColorsMode = false
 			removeColorPicker(this, eventsForLaunchpad, guiButtons, commandChannels)
+		}
+
+		if this.ScannerChaser {
+			common.HideSequence(this.ChaserSequenceNumber, commandChannels)
+			common.ClearSelectedRowOfButtons(this.SelectedSequence, eventsForLaunchpad, guiButtons)
+			this.SelectMode[this.SelectedSequence] = NORMAL
 		}
 
 		// S T O P - If sequence is running, stop it

--- a/pkg/buttons/buttons.go
+++ b/pkg/buttons/buttons.go
@@ -1038,6 +1038,8 @@ func ProcessButtons(X int, Y int,
 			this.SelectMode[this.SelectedSequence] = NORMAL
 		}
 
+		this.StaticFlashing = false
+
 		// S T O P - If sequence is running, stop it
 		if this.Running[this.SelectedSequence] {
 			if debug {
@@ -1054,6 +1056,8 @@ func ProcessButtons(X int, Y int,
 			this.Running[this.SelectedSequence] = false
 			this.Functions[this.SelectedSequence][common.Function6_Static_Gobo].State = false
 			this.Functions[this.SelectedSequence][common.Function8_Music_Trigger].State = false
+			this.Functions[this.ChaserSequenceNumber][common.Function6_Static_Gobo].State = false
+			this.Functions[this.ChaserSequenceNumber][common.Function8_Music_Trigger].State = false
 
 			// Stop should also stop the shutter chaser.
 			if this.SelectedType == "scanner" && this.ScannerChaser[this.SelectedSequence] {
@@ -1068,6 +1072,8 @@ func ProcessButtons(X int, Y int,
 
 				this.Functions[this.SelectedSequence][common.Function6_Static_Gobo].State = false
 				this.Functions[this.SelectedSequence][common.Function7_Invert_Chase].State = false
+				this.Functions[this.ChaserSequenceNumber][common.Function6_Static_Gobo].State = false
+				this.Functions[this.ChaserSequenceNumber][common.Function8_Music_Trigger].State = false
 				this.ScannerChaser[this.SelectedSequence] = false
 				this.SelectMode[this.SelectedSequence] = NORMAL
 				this.Running[this.ChaserSequenceNumber] = false

--- a/pkg/buttons/buttons.go
+++ b/pkg/buttons/buttons.go
@@ -1918,19 +1918,17 @@ func ProcessButtons(X int, Y int,
 
 		if this.SelectAllStaticFixtures {
 			// Set the same static color for all.
-			for fixtureNumber := 0; fixtureNumber < 8; fixtureNumber++ {
-				cmd := common.Command{
-					Action: common.UpdateStaticColor,
-					Args: []common.Arg{
-						{Name: "Static", Value: true},
-						{Name: "FixtureNumber", Value: fixtureNumber},
-						{Name: "StaticLampFlash", Value: false},
-						{Name: "SelectedColor", Value: sequences[this.TargetSequence].StaticColors[this.SelectedStaticFixtureNumber].SelectedColor},
-						{Name: "StaticColor", Value: sequences[this.TargetSequence].StaticColors[this.SelectedStaticFixtureNumber].Color},
-					},
-				}
-				common.SendCommandToSequence(this.TargetSequence, cmd, commandChannels)
+			cmd := common.Command{
+				Action: common.UpdateAllStaticColor,
+				Args: []common.Arg{
+					{Name: "Static", Value: true},
+					{Name: "StaticLampFlash", Value: false},
+					{Name: "SelectedColor", Value: sequences[this.TargetSequence].StaticColors[this.SelectedStaticFixtureNumber].SelectedColor},
+					{Name: "StaticColor", Value: sequences[this.TargetSequence].StaticColors[this.SelectedStaticFixtureNumber].Color},
+				},
 			}
+			common.SendCommandToSequence(this.TargetSequence, cmd, commandChannels)
+
 			this.SelectAllStaticFixtures = false
 
 		} else {

--- a/pkg/buttons/clear.go
+++ b/pkg/buttons/clear.go
@@ -48,7 +48,7 @@ func Clear(X int, Y int, this *CurrentState, sequences []*common.Sequence, dmxCo
 		sequences[this.TargetSequence].CurrentColors = sequences[this.TargetSequence].SequenceColors
 
 		// Flash the correct color buttons
-		ShowRGBColorPicker(this.MasterBrightness, *sequences[this.EditWhichSequence], this.DisplaySequence, eventsForLaunchpad, guiButtons)
+		ShowRGBColorPicker(this.MasterBrightness, *sequences[this.EditWhichSequence], this.DisplaySequence, eventsForLaunchpad, guiButtons, commandChannels)
 
 		// Clear has been pressed, next time we press clear we will get the full clear.
 		this.ClearPressed[this.TargetSequence] = true

--- a/pkg/buttons/clear.go
+++ b/pkg/buttons/clear.go
@@ -45,16 +45,16 @@ func Clear(X int, Y int, this *CurrentState, sequences []*common.Sequence, dmxCo
 		cmd := common.Command{
 			Action: common.ClearSequenceColor,
 		}
-		common.SendCommandToSequence(this.EditWhichSequence, cmd, commandChannels)
+		common.SendCommandToSequence(this.EditWhichStaticSequence, cmd, commandChannels)
 
 		// Get an upto date copy of the sequence.
-		sequences[this.EditWhichSequence] = common.RefreshSequence(this.EditWhichSequence, commandChannels, updateChannels)
+		sequences[this.EditWhichStaticSequence] = common.RefreshSequence(this.EditWhichStaticSequence, commandChannels, updateChannels)
 
 		// Set the colors.
 		sequences[this.TargetSequence].CurrentColors = sequences[this.TargetSequence].SequenceColors
 
 		// Flash the correct color buttons
-		ShowRGBColorPicker(this.MasterBrightness, *sequences[this.EditWhichSequence], this.DisplaySequence, eventsForLaunchpad, guiButtons, commandChannels)
+		ShowRGBColorPicker(this.MasterBrightness, *sequences[this.EditWhichStaticSequence], this.DisplaySequence, eventsForLaunchpad, guiButtons, commandChannels)
 
 		// Clear has been pressed, next time we press clear we will get the full clear.
 		this.ClearPressed[this.TargetSequence] = true
@@ -63,13 +63,13 @@ func Clear(X int, Y int, this *CurrentState, sequences []*common.Sequence, dmxCo
 	}
 
 	// Shortcut to clear static colors. We want to clear a static color selection for a selected sequence.
-	if this.EditStaticColorsMode[this.EditWhichSequence] && !this.ClearPressed[this.TargetSequence] {
+	if this.EditStaticColorsMode[this.EditWhichStaticSequence] && !this.ClearPressed[this.TargetSequence] {
 
 		if debug {
 			fmt.Printf("Shortcut to clear static colors\n")
 		}
 
-		if this.EditStaticColorsMode[this.EditWhichSequence] && this.EditSequenceColorPickerMode {
+		if this.EditStaticColorsMode[this.EditWhichStaticSequence] && this.EditSequenceColorPickerMode {
 			if debug {
 				fmt.Printf("removeColorPicker\n")
 			}

--- a/pkg/buttons/clear.go
+++ b/pkg/buttons/clear.go
@@ -170,6 +170,7 @@ func Clear(X int, Y int, this *CurrentState, sequences []*common.Sequence, dmxCo
 		this.EditScannerColorsMode = false                                           // Clear scanner color mode.
 		this.ShowRGBColorPicker = false                                              // Clear rgb color mode.
 		this.EditStaticColorsMode[this.TargetSequence] = false                       // Clear static color mode.
+		this.ShowStaticColorPicker = false                                           // Clear the static color picker.
 		this.MasterBrightness = common.MAX_DMX_BRIGHTNESS                            // Reset brightness to max.
 
 		// Enable all fixtures.

--- a/pkg/buttons/clear.go
+++ b/pkg/buttons/clear.go
@@ -172,7 +172,7 @@ func Clear(X int, Y int, this *CurrentState, sequences []*common.Sequence, dmxCo
 		this.EditStaticColorsMode[this.TargetSequence] = false                       // Clear static color mode.
 		this.ShowStaticColorPicker = false                                           // Clear the static color picker.
 		this.MasterBrightness = common.MAX_DMX_BRIGHTNESS                            // Reset brightness to max.
-		this.StaticFlashing = false                                                  // Turn off any flashing static buttons.
+		this.StaticFlashing[sequenceNumber] = false                                  // Turn off any flashing static buttons.
 
 		// Enable all fixtures.
 		for fixtureNumber := 0; fixtureNumber < sequence.NumberFixtures; fixtureNumber++ {

--- a/pkg/buttons/clear.go
+++ b/pkg/buttons/clear.go
@@ -143,6 +143,7 @@ func Clear(X int, Y int, this *CurrentState, sequences []*common.Sequence, dmxCo
 		this.OffsetTilt = common.SCANNER_MID_POINT                                   // Reset tilt to the center
 		this.ScannerCoordinates[sequenceNumber] = common.DEFAULT_SCANNER_COORDNIATES // Reset the number of coordinates.
 		this.ScannerSize[this.SelectedSequence] = common.DEFAULT_SCANNER_SIZE        // Reset the scanner size back to default.
+		this.ScannerChaser[sequenceNumber] = false                                   // Clear the scanner chase mode.
 		this.ScannerPattern = common.DEFAULT_PATTERN                                 // Reset the scanner pattern back to default.
 		this.SwitchPositions = [9][9]int{}                                           // Clear switch positions to their first positions.
 		this.EditFixtureSelectionMode = false                                        // Clear fixture selecetd mode.
@@ -154,7 +155,6 @@ func Clear(X int, Y int, this *CurrentState, sequences []*common.Sequence, dmxCo
 		this.EditSequenceColorsMode = false                                          // Clear rgb color mode.
 		this.EditStaticColorsMode[this.TargetSequence] = false                       // Clear static color mode.
 		this.MasterBrightness = common.MAX_DMX_BRIGHTNESS                            // Reset brightness to max.
-		this.ScannerChaser = false                                                   // Clear the scanner chase mode.
 
 		// Enable all fixtures.
 		for fixtureNumber := 0; fixtureNumber < sequence.NumberFixtures; fixtureNumber++ {

--- a/pkg/buttons/clear.go
+++ b/pkg/buttons/clear.go
@@ -172,6 +172,7 @@ func Clear(X int, Y int, this *CurrentState, sequences []*common.Sequence, dmxCo
 		this.EditStaticColorsMode[this.TargetSequence] = false                       // Clear static color mode.
 		this.ShowStaticColorPicker = false                                           // Clear the static color picker.
 		this.MasterBrightness = common.MAX_DMX_BRIGHTNESS                            // Reset brightness to max.
+		this.StaticFlashing = false                                                  // Turn off any flashing static buttons.
 
 		// Enable all fixtures.
 		for fixtureNumber := 0; fixtureNumber < sequence.NumberFixtures; fixtureNumber++ {

--- a/pkg/buttons/clear.go
+++ b/pkg/buttons/clear.go
@@ -35,7 +35,7 @@ func Clear(X int, Y int, this *CurrentState, sequences []*common.Sequence, dmxCo
 	}
 
 	// Shortcut to clear rgb chase colors. We want to clear a color selection for a selected sequence.
-	if this.EditSequenceColorPickerMode && !this.ClearPressed[this.TargetSequence] {
+	if this.ShowRGBColorPicker && !this.ClearPressed[this.TargetSequence] {
 
 		if debug {
 			fmt.Printf("Shortcut to clear rgb chase colors\n")
@@ -69,7 +69,7 @@ func Clear(X int, Y int, this *CurrentState, sequences []*common.Sequence, dmxCo
 			fmt.Printf("Shortcut to clear static colors\n")
 		}
 
-		if this.EditStaticColorsMode[this.EditWhichStaticSequence] && this.EditSequenceColorPickerMode {
+		if this.EditStaticColorsMode[this.EditWhichStaticSequence] && this.ShowRGBColorPicker {
 			if debug {
 				fmt.Printf("removeColorPicker\n")
 			}
@@ -168,7 +168,7 @@ func Clear(X int, Y int, this *CurrentState, sequences []*common.Sequence, dmxCo
 		this.EditGoboSelectionMode = false                                           // Clear edit gobo mode.
 		this.EditPatternMode = false                                                 // Clear edit pattern mode.
 		this.EditScannerColorsMode = false                                           // Clear scanner color mode.
-		this.EditSequenceColorPickerMode = false                                     // Clear rgb color mode.
+		this.ShowRGBColorPicker = false                                              // Clear rgb color mode.
 		this.EditStaticColorsMode[this.TargetSequence] = false                       // Clear static color mode.
 		this.MasterBrightness = common.MAX_DMX_BRIGHTNESS                            // Reset brightness to max.
 

--- a/pkg/buttons/clear.go
+++ b/pkg/buttons/clear.go
@@ -22,7 +22,6 @@ import (
 	"github.com/dhowlett99/dmxlights/pkg/common"
 	"github.com/dhowlett99/dmxlights/pkg/fixture"
 	"github.com/dhowlett99/dmxlights/pkg/presets"
-	"github.com/dhowlett99/dmxlights/pkg/sequence"
 	"github.com/oliread/usbdmx/ft232"
 )
 
@@ -217,7 +216,7 @@ func Clear(X int, Y int, this *CurrentState, sequences []*common.Sequence, dmxCo
 	common.SendCommandToAllSequence(cmd, commandChannels)
 
 	// Light the correct sequence selector button.
-	sequence.SequenceSelect(eventsForLaunchpad, guiButtons, this.SelectedSequence)
+	SequenceSelect(eventsForLaunchpad, guiButtons, this)
 
 	// Clear the graphics labels.
 	HandleSelect(sequences, this, eventsForLaunchpad, commandChannels, guiButtons)

--- a/pkg/buttons/functions.go
+++ b/pkg/buttons/functions.go
@@ -69,7 +69,7 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 			state := this.Functions[this.TargetSequence][functionNumber].State
 			fmt.Printf("FUNCS: function %d state %t\n", functionNumber, state)
 		}
-		fmt.Printf("FUNCS: this.ChaserRunning %t \n", this.ScannerChaser)
+		fmt.Printf("FUNCS: this.ChaserRunning %t \n", this.ScannerChaser[this.DisplaySequence])
 
 		fmt.Printf("================== WHAT SELECT MODE =================\n")
 		fmt.Printf("FUNCS: this.SelectButtonPressed[%d] = %t \n", this.DisplaySequence, this.SelectButtonPressed[this.DisplaySequence])
@@ -317,7 +317,7 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 		// Start off in single fixture edit mode.
 		this.SelectAllStaticFixtures = false
 
-		if this.ScannerChaser {
+		if this.ScannerChaser[this.SelectedSequence] {
 			// Turn on edit static color mode in the scanner sequence.
 			this.EditStaticColorsMode[this.ScannerSequenceNumber] = true
 		}
@@ -367,7 +367,7 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 		this.EditStaticColorsMode[this.TargetSequence] = false // Turn off edit static color mode.
 		this.SelectMode[this.TargetSequence] = NORMAL          // Turn off function selection mode.
 
-		if this.ScannerChaser {
+		if this.ScannerChaser[this.SelectedSequence] {
 			// Turn on edit static color mode in the scanner sequence.
 			this.EditStaticColorsMode[this.ScannerSequenceNumber] = true
 		}
@@ -492,7 +492,7 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 
 	// Function 7 - Toggle the shutter chaser mode. Start the chaser.
 	if X == common.Function7_Invert_Chase &&
-		!this.ScannerChaser &&
+		!this.ScannerChaser[this.SelectedSequence] &&
 		!this.Functions[this.TargetSequence][common.Function7_Invert_Chase].State &&
 		sequences[this.TargetSequence].Type == "scanner" {
 
@@ -500,7 +500,7 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 			fmt.Printf("Seq%d: Mode:%d common.Function7_Invert_Chase Scanner Shutter Chaser Mode On\n", this.TargetSequence, this.SelectMode[this.TargetSequence])
 		}
 
-		this.ScannerChaser = true
+		this.ScannerChaser[this.SelectedSequence] = true
 		this.Functions[this.TargetSequence][common.Function7_Invert_Chase].State = true // Chaser
 
 		ShowFunctionButtons(this, eventsForLaunchpad, guiButtons)
@@ -510,7 +510,7 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 		cmd := common.Command{
 			Action: common.UpdateScannerHasShutterChase,
 			Args: []common.Arg{
-				{Name: "ScannerHasShutterChase", Value: this.ScannerChaser},
+				{Name: "ScannerHasShutterChase", Value: this.ScannerChaser[this.SelectedSequence]},
 			},
 		}
 		common.SendCommandToSequence(this.ScannerSequenceNumber, cmd, commandChannels)
@@ -531,7 +531,7 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 
 	// Function 7 - Toggle the shutter chaser mode off. Stop the chaser.
 	if X == common.Function7_Invert_Chase &&
-		this.ScannerChaser &&
+		this.ScannerChaser[this.SelectedSequence] &&
 		this.Functions[this.TargetSequence][common.Function7_Invert_Chase].State &&
 		sequences[this.TargetSequence].Type == "scanner" {
 
@@ -539,7 +539,7 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 			fmt.Printf("Seq%d: Mode:%d common.Function7_Invert_Chase Scanner Shutter Chaser Mode Off\n", this.TargetSequence, this.SelectMode[this.TargetSequence])
 		}
 
-		this.ScannerChaser = false
+		this.ScannerChaser[this.SelectedSequence] = false
 		this.Functions[this.TargetSequence][common.Function7_Invert_Chase].State = false
 
 		ShowFunctionButtons(this, eventsForLaunchpad, guiButtons)
@@ -550,7 +550,7 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 		cmd := common.Command{
 			Action: common.UpdateScannerHasShutterChase,
 			Args: []common.Arg{
-				{Name: "ScannerHasShutterChase", Value: this.ScannerChaser},
+				{Name: "ScannerHasShutterChase", Value: this.ScannerChaser[this.SelectedSequence]},
 			},
 		}
 		common.SendCommandToSequence(this.SelectedSequence, cmd, commandChannels)
@@ -649,17 +649,17 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 		}
 
 		this.Functions[this.TargetSequence][common.Function8_Music_Trigger].State = false
-		this.ScannerChaser = false
+		this.ScannerChaser[this.SelectedSequence] = false
 
 		ShowFunctionButtons(this, eventsForLaunchpad, guiButtons)
 		time.Sleep(500 * time.Millisecond) // But give the launchpad time to light the function key purple.
 
 		// Tell scanner & chaser sequence that the scanner shutter chase flag is off.
-		this.Running[this.ChaserSequenceNumber] = this.ScannerChaser
+		this.Running[this.ChaserSequenceNumber] = this.ScannerChaser[this.SelectedSequence]
 		cmd := common.Command{
 			Action: common.UpdateScannerHasShutterChase,
 			Args: []common.Arg{
-				{Name: "ScannerHasShutterChase", Value: this.ScannerChaser},
+				{Name: "ScannerHasShutterChase", Value: this.ScannerChaser[this.SelectedSequence]},
 			},
 		}
 		common.SendCommandToSequence(this.DisplaySequence, cmd, commandChannels)
@@ -669,7 +669,7 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 		cmd = common.Command{
 			Action: common.UpdateMusicTrigger,
 			Args: []common.Arg{
-				{Name: "MusicTriger", Value: this.ScannerChaser},
+				{Name: "MusicTriger", Value: this.ScannerChaser[this.SelectedSequence]},
 			},
 		}
 		common.SendCommandToSequence(this.ChaserSequenceNumber, cmd, commandChannels)

--- a/pkg/buttons/functions.go
+++ b/pkg/buttons/functions.go
@@ -73,7 +73,7 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 
 		fmt.Printf("================== WHAT SELECT MODE =================\n")
 		fmt.Printf("FUNCS: this.SelectButtonPressed[%d] = %t \n", this.DisplaySequence, this.SelectButtonPressed[this.DisplaySequence])
-		printMode(this)
+		fmt.Printf("Mode : %s\n", printMode(this.SelectMode[this.SelectedSequence]))
 		fmt.Printf("================== WHAT EDIT MODES =================\n")
 		fmt.Printf("FUNCS: this.ShowRGBColorPicker[%d] = %t \n", this.DisplaySequence, this.ShowRGBColorPicker)
 		fmt.Printf("FUNCS: this.EditStaticColorsMode[%d] = %t \n", this.DisplaySequence, this.EditStaticColorsMode)
@@ -576,6 +576,9 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 		}
 		common.SendCommandToSequence(this.ChaserSequenceNumber, cmd, commandChannels)
 
+		// Update the labels.
+		showStatusBar(this, sequences, guiButtons)
+
 		ShowFunctionButtons(this, eventsForLaunchpad, guiButtons)
 		return
 	}
@@ -615,7 +618,7 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 		}
 		common.SendCommandToSequence(this.ChaserSequenceNumber, cmd, commandChannels)
 
-		// Update the labek.
+		// Update the labels.
 		showStatusBar(this, sequences, guiButtons)
 
 		ShowFunctionButtons(this, eventsForLaunchpad, guiButtons)

--- a/pkg/buttons/functions.go
+++ b/pkg/buttons/functions.go
@@ -404,6 +404,7 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 
 		this.EditGoboSelectionMode = false                     // Turn off the other option for this function key.
 		this.EditStaticColorsMode[this.TargetSequence] = false // Turn off edit static color mode.
+		this.ShowStaticColorPicker = false                     // Turn off the color picker.
 		this.SelectMode[this.TargetSequence] = NORMAL          // Turn off function selection mode.
 
 		if this.ScannerChaser[this.SelectedSequence] {
@@ -439,6 +440,7 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 
 		this.Functions[this.TargetSequence][common.Function6_Static_Gobo].State = true
 		this.EditStaticColorsMode[this.TargetSequence] = false // Turn off the other option for this function key.
+		this.ShowStaticColorPicker = false
 		this.EditGoboSelectionMode = true
 
 		ShowFunctionButtons(this, eventsForLaunchpad, guiButtons)

--- a/pkg/buttons/functions.go
+++ b/pkg/buttons/functions.go
@@ -414,7 +414,7 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 
 		this.Functions[this.TargetSequence][common.Function6_Static_Gobo].State = false // Turn off static color off.
 		this.EditGoboSelectionMode = false                                              // Turn off the other option for this function key.
-		this.EditStaticColorsMode[this.TargetSequence] = false                          // Turn off edit static color mode.
+		this.EditStaticColorsMode[this.DisplaySequence] = false                         // Turn off edit static color mode.
 		this.ShowStaticColorPicker = false                                              // Turn off the color picker.
 		this.StaticFlashing[this.SelectedSequence] = false                              // Stop any flash commands being issued.
 

--- a/pkg/buttons/functions.go
+++ b/pkg/buttons/functions.go
@@ -418,7 +418,7 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 		this.EditStaticColorsMode[this.TargetSequence] = false // Turn off edit static color mode.
 		this.ShowStaticColorPicker = false                     // Turn off the color picker.
 		this.SelectMode[this.TargetSequence] = NORMAL          // Turn off function selection mode.
-		this.StaticFlashing = false                            // Stop any flash commands being issued.
+		this.StaticFlashing[this.SelectedSequence] = false     // Stop any flash commands being issued.
 
 		if this.ScannerChaser[this.SelectedSequence] {
 			// Turn on edit static color mode in the scanner sequence.

--- a/pkg/buttons/functions.go
+++ b/pkg/buttons/functions.go
@@ -576,9 +576,6 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 		}
 		common.SendCommandToSequence(this.ChaserSequenceNumber, cmd, commandChannels)
 
-		// Jump straight to showing the shutter chaser.
-		this.DisplayChaserShortCut = true
-
 		ShowFunctionButtons(this, eventsForLaunchpad, guiButtons)
 		return
 	}

--- a/pkg/buttons/functions.go
+++ b/pkg/buttons/functions.go
@@ -412,18 +412,14 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 			fmt.Printf("Seq%d: Mode:%d common.Function6_Static_Gobo RGB Static Color Mode Off\n", this.TargetSequence, this.SelectMode[this.TargetSequence])
 		}
 
-		this.Functions[this.TargetSequence][common.Function6_Static_Gobo].State = false
+		this.Functions[this.TargetSequence][common.Function6_Static_Gobo].State = false // Turn off static color off.
+		this.EditGoboSelectionMode = false                                              // Turn off the other option for this function key.
+		this.EditStaticColorsMode[this.TargetSequence] = false                          // Turn off edit static color mode.
+		this.ShowStaticColorPicker = false                                              // Turn off the color picker.
+		this.StaticFlashing[this.SelectedSequence] = false                              // Stop any flash commands being issued.
 
-		this.EditGoboSelectionMode = false                     // Turn off the other option for this function key.
-		this.EditStaticColorsMode[this.TargetSequence] = false // Turn off edit static color mode.
-		this.ShowStaticColorPicker = false                     // Turn off the color picker.
-		this.SelectMode[this.TargetSequence] = NORMAL          // Turn off function selection mode.
-		this.StaticFlashing[this.SelectedSequence] = false     // Stop any flash commands being issued.
-
-		if this.ScannerChaser[this.SelectedSequence] {
-			// Turn on edit static color mode in the scanner sequence.
-			this.EditStaticColorsMode[this.ScannerSequenceNumber] = true
-		}
+		// Hide sequence.
+		common.HideSequence(this.TargetSequence, commandChannels)
 
 		// Go straight to static color selection mode, don't wait for a another select press.
 		ShowFunctionButtons(this, eventsForLaunchpad, guiButtons)
@@ -439,6 +435,17 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 			},
 		}
 		common.SendCommandToSequence(this.TargetSequence, cmd, commandChannels)
+
+		if this.ScannerChaser[this.SelectedSequence] {
+			// The static scene is being turned off so restart the shutter chaser.
+			this.Running[this.ChaserSequenceNumber] = true
+			// Tell the chaser to start.
+			cmd = common.Command{
+				Action: common.StartChase,
+			}
+			common.SendCommandToSequence(this.ChaserSequenceNumber, cmd, commandChannels)
+		}
+
 		common.RevealSequence(this.TargetSequence, commandChannels)
 		return
 	}

--- a/pkg/buttons/functions.go
+++ b/pkg/buttons/functions.go
@@ -522,6 +522,9 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 		}
 		common.SendCommandToSequence(this.ChaserSequenceNumber, cmd, commandChannels)
 
+		// CJump straigt to showing the shutter chaser.
+		this.DisplayChaserShortCut = true
+
 		HandleSelect(sequences, this, eventsForLaunchpad, commandChannels, guiButtons)
 		return
 	}

--- a/pkg/buttons/functions.go
+++ b/pkg/buttons/functions.go
@@ -75,7 +75,7 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 		fmt.Printf("FUNCS: this.SelectButtonPressed[%d] = %t \n", this.DisplaySequence, this.SelectButtonPressed[this.DisplaySequence])
 		printMode(this)
 		fmt.Printf("================== WHAT EDIT MODES =================\n")
-		fmt.Printf("FUNCS: this.EditSequenceColorPickerMode[%d] = %t \n", this.DisplaySequence, this.EditSequenceColorPickerMode)
+		fmt.Printf("FUNCS: this.ShowRGBColorPicker[%d] = %t \n", this.DisplaySequence, this.ShowRGBColorPicker)
 		fmt.Printf("FUNCS: this.EditStaticColorsMode[%d] = %t \n", this.DisplaySequence, this.EditStaticColorsMode)
 		fmt.Printf("FUNCS: this.EditGoboSelectionMode[%d] = %t \n", this.DisplaySequence, this.EditGoboSelectionMode)
 		fmt.Printf("FUNCS: this.EditPatternMode[%d] = %t \n", this.DisplaySequence, this.EditPatternMode)
@@ -280,7 +280,7 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 			fmt.Printf("Seq%d: Mode:%d common.Function5_Color RGB Color Mode \n", this.TargetSequence, this.SelectMode[this.TargetSequence])
 		}
 
-		this.EditSequenceColorPickerMode = true
+		this.ShowRGBColorPicker = true
 		this.Functions[this.TargetSequence][common.Function5_Color].State = true
 
 		time.Sleep(500 * time.Millisecond) // But give the launchpad time to light the function key purple.
@@ -554,6 +554,7 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 		}
 
 		this.ScannerChaser[this.SelectedSequence] = true
+		this.ScannerChaser[this.TargetSequence] = true
 		this.Functions[this.TargetSequence][common.Function7_Invert_Chase].State = true // Chaser
 
 		ShowFunctionButtons(this, eventsForLaunchpad, guiButtons)

--- a/pkg/buttons/functions.go
+++ b/pkg/buttons/functions.go
@@ -73,19 +73,7 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 
 		fmt.Printf("================== WHAT SELECT MODE =================\n")
 		fmt.Printf("FUNCS: this.SelectButtonPressed[%d] = %t \n", this.DisplaySequence, this.SelectButtonPressed[this.DisplaySequence])
-		if this.SelectMode[this.TargetSequence] == NORMAL {
-			fmt.Printf("FUNCS: this.SelectMode[%d] = NORMAL \n", this.DisplaySequence)
-		}
-		if this.SelectMode[this.TargetSequence] == FUNCTION {
-			fmt.Printf("FUNCS: this.SelectMode[%d] = FUNCTION \n", this.SelectedSequence)
-		}
-		if this.SelectMode[this.TargetSequence] == CHASER_FUNCTION {
-			fmt.Printf("FUNCS: this.SelectMode[%d] = CHASER_FUNCTION \n", this.SelectedSequence)
-		}
-		if this.SelectMode[this.TargetSequence] == STATUS {
-			fmt.Printf("FUNCS: this.SelectMode[%d] = STATUS \n", this.SelectedSequence)
-		}
-
+		printMode(this)
 		fmt.Printf("================== WHAT EDIT MODES =================\n")
 		fmt.Printf("FUNCS: this.EditSequenceColorsMode[%d] = %t \n", this.DisplaySequence, this.EditSequenceColorsMode)
 		fmt.Printf("FUNCS: this.EditStaticColorsMode[%d] = %t \n", this.DisplaySequence, this.EditStaticColorsMode)

--- a/pkg/buttons/functions.go
+++ b/pkg/buttons/functions.go
@@ -108,6 +108,12 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 
 		ShowPatternSelectionButtons(this, sequences[this.TargetSequence].Master, *sequences[this.TargetSequence], this.DisplaySequence, eventsForLaunchpad, guiButtons)
 
+		// If we are in the chaser function mode, we wannt to make sure the sequence shows the shutter chaser.
+		if this.SelectMode[this.DisplaySequence] == CHASER_FUNCTION {
+			// Jump straight to showing the shutter chaser.
+			this.DisplayChaserShortCut = true
+		}
+
 		return
 	}
 
@@ -130,6 +136,13 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 		common.SendCommandToSequence(this.TargetSequence, cmd, commandChannels)
 
 		ShowFunctionButtons(this, eventsForLaunchpad, guiButtons)
+
+		// If we are in the chaser function mode, we wannt to make sure the sequence shows the shutter chaser.
+		if this.SelectMode[this.DisplaySequence] == CHASER_FUNCTION {
+			// Jump straight to showing the shutter chaser.
+			this.DisplayChaserShortCut = true
+		}
+
 		return
 	}
 	if X == common.Function2_Auto_Color && this.Functions[this.TargetSequence][common.Function2_Auto_Color].State {
@@ -171,6 +184,13 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 		common.SendCommandToSequence(this.TargetSequence, cmd, commandChannels)
 
 		ShowFunctionButtons(this, eventsForLaunchpad, guiButtons)
+
+		// If we are in the chaser function mode, we wannt to make sure the sequence shows the shutter chaser.
+		if this.SelectMode[this.DisplaySequence] == CHASER_FUNCTION {
+			// Jump straight to showing the shutter chaser.
+			this.DisplayChaserShortCut = true
+		}
+
 		return
 	}
 	if X == common.Function3_Auto_Pattern && this.Functions[this.TargetSequence][common.Function3_Auto_Pattern].State {
@@ -193,7 +213,7 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 		return
 	}
 
-	// Function 4 Bounce - Toggle bounce feature.
+	// Function 4 Bounce - Toggle bounce feature on.
 	if X == common.Function4_Bounce && !this.Functions[this.TargetSequence][common.Function4_Bounce].State {
 
 		if debug {
@@ -211,8 +231,16 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 		common.SendCommandToSequence(this.TargetSequence, cmd, commandChannels)
 
 		ShowFunctionButtons(this, eventsForLaunchpad, guiButtons)
+
+		// If we are in the chaser function mode, we wannt to make sure the sequence shows the shutter chaser.
+		if this.SelectMode[this.DisplaySequence] == CHASER_FUNCTION {
+			// Jump straight to showing the shutter chaser.
+			this.DisplayChaserShortCut = true
+		}
+
 		return
 	}
+	// Function 4 Bounce - Toggle bounce feature off.
 	if X == common.Function4_Bounce && this.Functions[this.TargetSequence][common.Function4_Bounce].State {
 
 		if debug {
@@ -450,6 +478,13 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 		}
 
 		ShowFunctionButtons(this, eventsForLaunchpad, guiButtons)
+
+		// If we are in the chaser function mode, we wannt to make sure the sequence shows the shutter chaser.
+		if this.SelectMode[this.DisplaySequence] == CHASER_FUNCTION {
+			// Jump straight to showing the shutter chaser.
+			this.DisplayChaserShortCut = true
+		}
+
 		return
 	}
 
@@ -522,7 +557,7 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 		}
 		common.SendCommandToSequence(this.ChaserSequenceNumber, cmd, commandChannels)
 
-		// Jump straigt to showing the shutter chaser.
+		// Jump straight to showing the shutter chaser.
 		this.DisplayChaserShortCut = true
 
 		HandleSelect(sequences, this, eventsForLaunchpad, commandChannels, guiButtons)
@@ -606,6 +641,12 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 			},
 		}
 		common.SendCommandToSequence(this.TargetSequence, cmd, commandChannels)
+
+		// If we are in the chaser function mode, we wannt to make sure the sequence shows the shutter chaser.
+		if this.SelectMode[this.DisplaySequence] == CHASER_FUNCTION {
+			// Jump straight to showing the shutter chaser.
+			this.DisplayChaserShortCut = true
+		}
 
 		// We want to exit from functioms immediately so we call handle.
 		HandleSelect(sequences, this, eventsForLaunchpad, commandChannels, guiButtons)

--- a/pkg/buttons/functions.go
+++ b/pkg/buttons/functions.go
@@ -560,7 +560,7 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 		// Jump straight to showing the shutter chaser.
 		this.DisplayChaserShortCut = true
 
-		HandleSelect(sequences, this, eventsForLaunchpad, commandChannels, guiButtons)
+		ShowFunctionButtons(this, eventsForLaunchpad, guiButtons)
 		return
 	}
 
@@ -610,7 +610,7 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 		common.LabelButton(6, 7, "Fase\nSoft", guiButtons)
 		common.LabelButton(7, 7, "Fade\nSharp", guiButtons)
 
-		HandleSelect(sequences, this, eventsForLaunchpad, commandChannels, guiButtons)
+		ShowFunctionButtons(this, eventsForLaunchpad, guiButtons)
 		return
 	}
 
@@ -648,8 +648,7 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 			this.DisplayChaserShortCut = true
 		}
 
-		// We want to exit from functioms immediately so we call handle.
-		HandleSelect(sequences, this, eventsForLaunchpad, commandChannels, guiButtons)
+		ShowFunctionButtons(this, eventsForLaunchpad, guiButtons)
 		return
 	}
 
@@ -675,8 +674,7 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 		}
 		common.SendCommandToSequence(this.TargetSequence, cmd, commandChannels)
 
-		// We want to exit from functioms immediately so we call handle.
-		HandleSelect(sequences, this, eventsForLaunchpad, commandChannels, guiButtons)
+		ShowFunctionButtons(this, eventsForLaunchpad, guiButtons)
 		return
 	}
 
@@ -715,8 +713,7 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 		}
 		common.SendCommandToSequence(this.ChaserSequenceNumber, cmd, commandChannels)
 
-		// We want to exit from functioms immediately so we call handle.
-		HandleSelect(sequences, this, eventsForLaunchpad, commandChannels, guiButtons)
+		ShowFunctionButtons(this, eventsForLaunchpad, guiButtons)
 		return
 	}
 }

--- a/pkg/buttons/functions.go
+++ b/pkg/buttons/functions.go
@@ -33,10 +33,10 @@ func ShowFunctionButtons(this *CurrentState, eventsForLauchpad chan common.ALigh
 		if debug {
 			fmt.Printf("ShowFunctionButtons: function %s state %t\n", function.Name, function.State)
 		}
-		if !function.State && this.SelectMode[this.DisplaySequence] != CHASER { // Cyan
+		if !function.State && this.SelectMode[this.DisplaySequence] != CHASER_FUNCTION { // Cyan
 			common.LightLamp(common.ALight{X: index, Y: this.DisplaySequence, Brightness: 255, Red: 3, Green: 255, Blue: 255}, eventsForLauchpad, guiButtons)
 		}
-		if !function.State && this.SelectMode[this.DisplaySequence] == CHASER { // Yellow
+		if !function.State && this.SelectMode[this.DisplaySequence] == CHASER_FUNCTION { // Yellow
 			common.LightLamp(common.ALight{X: index, Y: this.DisplaySequence, Brightness: 255, Red: 255, Green: 255, Blue: 0}, eventsForLauchpad, guiButtons)
 		}
 		if function.State { // Purple
@@ -50,7 +50,7 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 
 	debug := false
 
-	if this.SelectMode[this.SelectedSequence] == CHASER {
+	if this.SelectMode[this.SelectedSequence] == CHASER_FUNCTION {
 		this.TargetSequence = this.ChaserSequenceNumber
 		this.DisplaySequence = this.SelectedSequence
 	} else {
@@ -79,8 +79,8 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 		if this.SelectMode[this.TargetSequence] == FUNCTION {
 			fmt.Printf("FUNCS: this.SelectMode[%d] = FUNCTION \n", this.SelectedSequence)
 		}
-		if this.SelectMode[this.TargetSequence] == CHASER {
-			fmt.Printf("FUNCS: this.SelectMode[%d] = CHASER \n", this.SelectedSequence)
+		if this.SelectMode[this.TargetSequence] == CHASER_FUNCTION {
+			fmt.Printf("FUNCS: this.SelectMode[%d] = CHASER_FUNCTION \n", this.SelectedSequence)
 		}
 		if this.SelectMode[this.TargetSequence] == STATUS {
 			fmt.Printf("FUNCS: this.SelectMode[%d] = STATUS \n", this.SelectedSequence)
@@ -492,6 +492,7 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 
 	// Function 7 - Toggle the shutter chaser mode. Start the chaser.
 	if X == common.Function7_Invert_Chase &&
+		!this.ScannerChaser &&
 		!this.Functions[this.TargetSequence][common.Function7_Invert_Chase].State &&
 		sequences[this.TargetSequence].Type == "scanner" {
 
@@ -521,25 +522,13 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 		}
 		common.SendCommandToSequence(this.ChaserSequenceNumber, cmd, commandChannels)
 
-		// Update the buttons: speed
-		common.LabelButton(0, 7, "Chase\nSpeed\nDown", guiButtons)
-		common.LabelButton(1, 7, "Chase\nSpeed\nUp", guiButtons)
-
-		common.LabelButton(2, 7, "Chase\nShift\nDown", guiButtons)
-		common.LabelButton(3, 7, "Chase\nShift\nUp", guiButtons)
-
-		common.LabelButton(4, 7, "Chase\nSize\nDown", guiButtons)
-		common.LabelButton(5, 7, "Chase\nSize\nUp", guiButtons)
-
-		common.LabelButton(6, 7, "Chase\nFase\nSoft", guiButtons)
-		common.LabelButton(7, 7, "Chase\nFade\nSharp", guiButtons)
-
 		HandleSelect(sequences, this, eventsForLaunchpad, commandChannels, guiButtons)
 		return
 	}
 
-	// Function 7 - Toggle the shutter chaser mode. Stop the chaser.
+	// Function 7 - Toggle the shutter chaser mode off. Stop the chaser.
 	if X == common.Function7_Invert_Chase &&
+		this.ScannerChaser &&
 		this.Functions[this.TargetSequence][common.Function7_Invert_Chase].State &&
 		sequences[this.TargetSequence].Type == "scanner" {
 
@@ -589,7 +578,7 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 
 	// Function 8 MUSIC TRIGGER  - Send start music trigger for scanner & rgb sequences.
 	if X == common.Function8_Music_Trigger &&
-		this.SelectMode[this.TargetSequence] != CHASER &&
+		this.SelectMode[this.TargetSequence] != CHASER_FUNCTION &&
 		!this.Functions[this.TargetSequence][common.Function8_Music_Trigger].State {
 
 		if debug {
@@ -649,7 +638,7 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 
 	// Function 8 MUSIC TRIGGER  - Send stop music trigger chaser sequences.
 	if X == common.Function8_Music_Trigger &&
-		this.SelectMode[this.TargetSequence] != CHASER &&
+		this.SelectMode[this.TargetSequence] != CHASER_FUNCTION &&
 		this.Functions[this.TargetSequence][common.Function8_Music_Trigger].State {
 
 		if debug {

--- a/pkg/buttons/functions.go
+++ b/pkg/buttons/functions.go
@@ -522,7 +522,7 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 		}
 		common.SendCommandToSequence(this.ChaserSequenceNumber, cmd, commandChannels)
 
-		// CJump straigt to showing the shutter chaser.
+		// Jump straigt to showing the shutter chaser.
 		this.DisplayChaserShortCut = true
 
 		HandleSelect(sequences, this, eventsForLaunchpad, commandChannels, guiButtons)

--- a/pkg/buttons/functions.go
+++ b/pkg/buttons/functions.go
@@ -351,6 +351,7 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 			fmt.Printf("Seq%d: Mode:%d common.Function6_Static_Gobo RGB Static Color Mode On\n", this.TargetSequence, this.SelectMode[this.TargetSequence])
 		}
 
+		this.Functions[this.TargetSequence][common.Function8_Music_Trigger].State = false
 		this.Functions[this.TargetSequence][common.Function6_Static_Gobo].State = true
 
 		// Start off in single fixture edit mode.
@@ -636,6 +637,7 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 			fmt.Printf("Seq%d: Mode:%d common.Function8_Music_Trigger Music Trigger Mode On\n", this.TargetSequence, this.SelectMode[this.TargetSequence])
 		}
 
+		this.Functions[this.TargetSequence][common.Function6_Static_Gobo].State = false
 		this.Functions[this.TargetSequence][common.Function8_Music_Trigger].State = true
 
 		ShowFunctionButtons(this, eventsForLaunchpad, guiButtons)

--- a/pkg/buttons/functions.go
+++ b/pkg/buttons/functions.go
@@ -117,7 +117,7 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 		return
 	}
 
-	// Function 2 Set Auto Color - Toggle the auto color feature.
+	// Function 2 Set Auto Color - Toggle the auto color feature on.
 	if X == common.Function2_Auto_Color && !this.Functions[this.TargetSequence][common.Function2_Auto_Color].State {
 
 		if debug {
@@ -145,6 +145,7 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 
 		return
 	}
+	// Function 2 Set Auto Color - Toggle the auto color feature off.
 	if X == common.Function2_Auto_Color && this.Functions[this.TargetSequence][common.Function2_Auto_Color].State {
 
 		if debug {
@@ -163,10 +164,17 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 		common.SendCommandToSequence(this.TargetSequence, cmd, commandChannels)
 
 		ShowFunctionButtons(this, eventsForLaunchpad, guiButtons)
+
+		// If we are in the chaser function mode, we wannt to make sure the sequence shows the shutter chaser.
+		if this.SelectMode[this.DisplaySequence] == CHASER_FUNCTION {
+			// Jump straight to showing the shutter chaser.
+			this.DisplayChaserShortCut = true
+		}
+
 		return
 	}
 
-	// Function 3 Set Auto Pattern - Toggle Auto Pattern.
+	// Function 3 Set Auto Pattern - Toggle Auto Pattern on.
 	if X == common.Function3_Auto_Pattern && !this.Functions[this.TargetSequence][common.Function3_Auto_Pattern].State {
 
 		if debug {
@@ -193,6 +201,7 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 
 		return
 	}
+	// Function 3 Set Auto Pattern - Toggle Auto Pattern off.
 	if X == common.Function3_Auto_Pattern && this.Functions[this.TargetSequence][common.Function3_Auto_Pattern].State {
 
 		if debug {
@@ -210,6 +219,13 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 		common.SendCommandToSequence(this.TargetSequence, cmd, commandChannels)
 
 		ShowFunctionButtons(this, eventsForLaunchpad, guiButtons)
+
+		// If we are in the chaser function mode, we wannt to make sure the sequence shows the shutter chaser.
+		if this.SelectMode[this.DisplaySequence] == CHASER_FUNCTION {
+			// Jump straight to showing the shutter chaser.
+			this.DisplayChaserShortCut = true
+		}
+
 		return
 	}
 
@@ -258,6 +274,13 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 		common.SendCommandToSequence(this.TargetSequence, cmd, commandChannels)
 
 		ShowFunctionButtons(this, eventsForLaunchpad, guiButtons)
+
+		// If we are in the chaser function mode, we wannt to make sure the sequence shows the shutter chaser.
+		if this.SelectMode[this.DisplaySequence] == CHASER_FUNCTION {
+			// Jump straight to showing the shutter chaser.
+			this.DisplayChaserShortCut = true
+		}
+
 		return
 	}
 
@@ -522,6 +545,13 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 		}
 
 		ShowFunctionButtons(this, eventsForLaunchpad, guiButtons)
+
+		// If we are in the chaser function mode, we wannt to make sure the sequence shows the shutter chaser.
+		if this.SelectMode[this.DisplaySequence] == CHASER_FUNCTION {
+			// Jump straight to showing the shutter chaser.
+			this.DisplayChaserShortCut = true
+		}
+
 		return
 	}
 
@@ -675,6 +705,13 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 		common.SendCommandToSequence(this.TargetSequence, cmd, commandChannels)
 
 		ShowFunctionButtons(this, eventsForLaunchpad, guiButtons)
+
+		// If we are in the chaser function mode, we wannt to make sure the sequence shows the shutter chaser.
+		if this.SelectMode[this.DisplaySequence] == CHASER_FUNCTION {
+			// Jump straight to showing the shutter chaser.
+			this.DisplayChaserShortCut = true
+		}
+
 		return
 	}
 

--- a/pkg/buttons/functions.go
+++ b/pkg/buttons/functions.go
@@ -302,7 +302,7 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 		this.SavedSequenceColors[this.SelectedSequence] = sequences[this.SelectedSequence].SequenceColors
 
 		// Remember which sequence we are editing
-		this.EditWhichSequence = this.TargetSequence
+		this.EditWhichStaticSequence = this.TargetSequence
 
 		// We use the whole launchpad for choosing from 24 colors.
 		common.HideAllSequences(commandChannels)
@@ -335,7 +335,7 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 		sequences[this.TargetSequence].StaticColors[X].FirstPress = false
 
 		// Remember which sequence we are editing
-		this.EditWhichSequence = this.TargetSequence
+		this.EditWhichStaticSequence = this.TargetSequence
 
 		this.FollowingAction = "ShowScannerColorSelectionButtons"
 		this.SelectedFixture = ShowSelectFixtureButtons(*sequences[this.TargetSequence], this.DisplaySequence, this, eventsForLaunchpad, this.FollowingAction, guiButtons)
@@ -387,7 +387,7 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 		common.RevealSequence(this.TargetSequence, commandChannels)
 
 		// Remember which sequence we are editing
-		this.EditWhichSequence = this.TargetSequence
+		this.EditWhichStaticSequence = this.TargetSequence
 
 		return
 	}
@@ -594,6 +594,8 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 
 		this.ScannerChaser[this.SelectedSequence] = false
 		this.Functions[this.TargetSequence][common.Function7_Invert_Chase].State = false
+		// Stopping the shutter chaser should also switch off any static scene.
+		this.Functions[this.TargetSequence][common.Function6_Static_Gobo].State = false
 
 		ShowFunctionButtons(this, eventsForLaunchpad, guiButtons)
 		time.Sleep(500 * time.Millisecond) // But give the launchpad time to light the function key purple.

--- a/pkg/buttons/functions.go
+++ b/pkg/buttons/functions.go
@@ -75,7 +75,7 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 		fmt.Printf("FUNCS: this.SelectButtonPressed[%d] = %t \n", this.DisplaySequence, this.SelectButtonPressed[this.DisplaySequence])
 		printMode(this)
 		fmt.Printf("================== WHAT EDIT MODES =================\n")
-		fmt.Printf("FUNCS: this.EditSequenceColorsMode[%d] = %t \n", this.DisplaySequence, this.EditSequenceColorsMode)
+		fmt.Printf("FUNCS: this.EditSequenceColorPickerMode[%d] = %t \n", this.DisplaySequence, this.EditSequenceColorPickerMode)
 		fmt.Printf("FUNCS: this.EditStaticColorsMode[%d] = %t \n", this.DisplaySequence, this.EditStaticColorsMode)
 		fmt.Printf("FUNCS: this.EditGoboSelectionMode[%d] = %t \n", this.DisplaySequence, this.EditGoboSelectionMode)
 		fmt.Printf("FUNCS: this.EditPatternMode[%d] = %t \n", this.DisplaySequence, this.EditPatternMode)
@@ -280,7 +280,7 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 			fmt.Printf("Seq%d: Mode:%d common.Function5_Color RGB Color Mode \n", this.TargetSequence, this.SelectMode[this.TargetSequence])
 		}
 
-		this.EditSequenceColorsMode = true
+		this.EditSequenceColorPickerMode = true
 		this.Functions[this.TargetSequence][common.Function5_Color].State = true
 
 		time.Sleep(500 * time.Millisecond) // But give the launchpad time to light the function key purple.

--- a/pkg/buttons/functions.go
+++ b/pkg/buttons/functions.go
@@ -308,7 +308,7 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 		common.HideAllSequences(commandChannels)
 
 		// Show the colors
-		ShowRGBColorPicker(this.MasterBrightness, *sequences[this.TargetSequence], this.DisplaySequence, eventsForLaunchpad, guiButtons)
+		ShowRGBColorPicker(this.MasterBrightness, *sequences[this.TargetSequence], this.DisplaySequence, eventsForLaunchpad, guiButtons, commandChannels)
 
 		return
 	}

--- a/pkg/buttons/functions.go
+++ b/pkg/buttons/functions.go
@@ -615,18 +615,8 @@ func processFunctions(X int, Y int, sequences []*common.Sequence, this *CurrentS
 		}
 		common.SendCommandToSequence(this.ChaserSequenceNumber, cmd, commandChannels)
 
-		// Update the buttons: speed
-		common.LabelButton(0, 7, "Speed\nDown", guiButtons)
-		common.LabelButton(1, 7, "Speed\nUp", guiButtons)
-
-		common.LabelButton(2, 7, "Shift\nDown", guiButtons)
-		common.LabelButton(3, 7, "Shift\nUp", guiButtons)
-
-		common.LabelButton(4, 7, "Size\nDown", guiButtons)
-		common.LabelButton(5, 7, "Size\nUp", guiButtons)
-
-		common.LabelButton(6, 7, "Fase\nSoft", guiButtons)
-		common.LabelButton(7, 7, "Fade\nSharp", guiButtons)
+		// Update the labek.
+		showStatusBar(this, sequences, guiButtons)
 
 		ShowFunctionButtons(this, eventsForLaunchpad, guiButtons)
 		return

--- a/pkg/buttons/handle.go
+++ b/pkg/buttons/handle.go
@@ -10,31 +10,31 @@ import (
 //		|       NORMAL      |
 //		+-------------------+
 //		    |            |
-//		    |            | If Scanner
-//	     |            | or if the DisplayChaserShortCut is set.
-//		    V            V
-//		    |       +-------------------+
-//		    |       |  CHASER DISPLAY   |
-//		    |       +-------------------+
-//		    V            |
-//		+-------------------+
-//		|     FUNCTION      |
-//		+-------------------+
-//		    |            | If Scanner
-//		    V            V
-//		    |       +-------------------+
-//		    |       |  CHASER FUNCTIONS |
-//		    |       +-------------------+
-//		    |		     |
-//		    V			 V
-//		 +-------------------+
-//		 |  FIXTURE STATUS   |
-//		 +-------------------+
-//		          |
-//		          V
-//		 +-------------------+
-//		 |       NORMAL      |
-//		 +-------------------+
+
+//	+-------------------+
+//	|     FUNCTION      |
+//	+-------------------+
+//	    |            | If Scanner
+//	    V            V
+//	    |       +-------------------+
+//	    |       |  CHASER DISPLAY   |
+//	    |       +-------------------+
+//	    V            |
+//	    |            | If Scanner
+//	    V            V
+//	    |       +-------------------+
+//	    |       |  CHASER FUNCTIONS |
+//	    |       +-------------------+
+//	    |		     |
+//	    V			 V
+//	 +-------------------+
+//	 |  FIXTURE STATUS   |
+//	 +-------------------+
+//	          |
+//	          V
+//	 +-------------------+
+//	 |       NORMAL      |
+//	 +-------------------+
 //
 // HandleSelect - Runs when you press a select button to select a sequence.
 func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLaunchpad chan common.ALight,
@@ -51,32 +51,384 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 	}
 
 	if debug {
-		fmt.Printf("HANDLE: this.Type = %s \n", this.SelectedType)
-		for functionNumber := 0; functionNumber < 8; functionNumber++ {
-			state := this.Functions[this.TargetSequence][functionNumber]
-			fmt.Printf("%d function %d state %+v\n", this.TargetSequence, functionNumber, state.State)
-		}
-		fmt.Printf("HANDLE:  SEQ: %d this.ScannerChaser running %t \n", this.DisplaySequence, this.ScannerChaser[this.DisplaySequence])
-
-		fmt.Printf("================== WHAT SELECT MODE =================\n")
-		fmt.Printf("HANDLE: this.SelectButtonPressed[%d] = %t \n", this.TargetSequence, this.SelectButtonPressed[this.TargetSequence])
-		printMode(this)
-
-		fmt.Printf("================== WHAT EDIT MODES =================\n")
-		fmt.Printf("HANDLE: this.DisplayChaserShortCut = %t \n", this.DisplayChaserShortCut)
-		fmt.Printf("HANDLE: this.EditSequenceColorPickerMode[%d] = %t \n", this.TargetSequence, this.EditSequenceColorPickerMode)
-		fmt.Printf("HANDLE: this.EditStaticColorsMode[%d] = %t \n", this.TargetSequence, this.EditStaticColorsMode)
-		fmt.Printf("HANDLE: this.EditGoboSelectionMode[%d] = %t \n", this.TargetSequence, this.EditGoboSelectionMode)
-		fmt.Printf("HANDLE: this.EditPatternMode[%d] = %t \n", this.TargetSequence, this.EditPatternMode)
-		fmt.Printf("HANDLE: this.EditColorPicker[%d] = %t \n", this.TargetSequence, this.EditColorPicker)
-		fmt.Printf("===============================================\n")
+		printHandleDebug(this)
 	}
 
+	// Select Chase Pattern.
+	if this.EditPatternMode {
+
+		if debug {
+			fmt.Printf("%d: If we're in pattern selection mode. turn off pattern func key\n", this.ChaserSequenceNumber)
+		}
+
+		// Reset the pattern function key.
+		this.Functions[this.SelectedSequence][common.Function1_Pattern].State = false
+
+		// Editing pattern is over for this sequence.
+		this.EditPatternMode = false
+
+		this.SelectMode[this.SelectedSequence] = NORMAL
+	}
+
+	// Select Chase Sequence Colors. Turn off the edit sequence colors button.
+	if this.ShowRGBColorPicker {
+		if debug {
+			fmt.Printf("Turn off the edit sequence colors button. \n")
+		}
+		this.ShowRGBColorPicker = false
+		this.Functions[this.EditWhichStaticSequence][common.Function5_Color].State = false
+		removeColorPicker(this, eventsForLaunchpad, guiButtons, commandChannels)
+		this.SelectMode[this.SelectedSequence] = NORMAL
+
+		// If the Selected Color has come back as empty this means we didn't select any colors.
+		// So restore the colors that were already there.
+		if debug {
+			fmt.Printf("sequences[%d].SequenceColors %+v\n", this.SelectedSequence, sequences[this.SelectedSequence].SequenceColors)
+		}
+		if len(sequences[this.SelectedSequence].SequenceColors) == 0 {
+			if debug {
+				fmt.Printf("Restore Sequence Colors\n")
+			}
+			sequences[this.SelectedSequence].SequenceColors = this.SavedSequenceColors[this.SelectedSequence]
+			if debug {
+				fmt.Printf("Now set to ----> sequences[%d].SequenceColors %+v\n", this.SelectedSequence, sequences[this.SelectedSequence].SequenceColors)
+			}
+			// Tell the sequence that we have restored the colors.
+			cmd := common.Command{
+				Action: common.UpdateSequenceColors,
+				Args: []common.Arg{
+					{Name: "Colors", Value: sequences[this.SelectedSequence].SequenceColors},
+				},
+			}
+			common.SendCommandToSequence(this.SelectedSequence, cmd, commandChannels)
+		}
+	}
+
+	// 1st Press Select Sequence - This the first time we have pressed the select button.
+	// Simply select the selected sequence.
+	// But remember we have pressed this select button once.
+	if this.SelectMode[this.DisplaySequence] == NORMAL && !this.SelectButtonPressed[this.DisplaySequence] {
+
+		if debug {
+			fmt.Printf("%d: Show Sequence - Handle Step 1\n", this.SelectedSequence)
+		}
+
+		// Assume everything else is off.
+		this.SelectButtonPressed[0] = false
+		this.SelectButtonPressed[1] = false
+		this.SelectButtonPressed[2] = false
+		this.SelectButtonPressed[3] = false
+
+		// Remember which select button has been pressed.
+		this.SelectButtonPressed[this.SelectedSequence] = true
+
+		// Now display the selected mode.
+		displayMode(this.SelectMode[this.SelectedSequence], this, sequences, eventsForLaunchpad, guiButtons, commandChannels)
+
+		return
+	}
+
+	// Fisrt option of the 2nd Press we are in rgb mode same select button go into Function Mode for this sequence.
+	// We're in Normal mode, We've Pressed twice. we're a rgb sequence.
+	// Or
+	// We're in Normal mode, We've Pressed twice. but the scanner chaser is off
+	// Or
+	// We're in Chaser Display mode. and scanner sequence.
+	if (this.SelectMode[this.SelectedSequence] == NORMAL && this.SelectedType == "rgb") ||
+		(this.SelectMode[this.SelectedSequence] == NORMAL && !this.ScannerChaser[this.SelectedSequence]) ||
+		(this.SelectMode[this.SelectedSequence] == CHASER_DISPLAY && this.SelectedType == "scanner") {
+
+		if debug {
+			fmt.Printf("%d: 2nd Press Function Bar Mode - Handle Step 2\n", this.SelectedSequence)
+		}
+
+		// Calculate the next mode.
+		this.SelectMode[this.SelectedSequence] = getNextMenuItem(this.SelectMode[this.SelectedSequence], this.ScannerChaser[this.SelectedSequence])
+
+		// Now forget we pressed twice and start again.
+		this.SelectButtonPressed[this.SelectedSequence] = false
+
+		// Now display the selected mode.
+		displayMode(this.SelectMode[this.SelectedSequence], this, sequences, eventsForLaunchpad, guiButtons, commandChannels)
+
+		return
+	}
+
+	// Second option of the 2nd Press in scanner mode go into Shutter Chaser Mode for this sequence.
+	// We're in Normal mode, We've Pressed twice and the scanner chaser is on and we're a scanner sequence.
+	if this.SelectMode[this.SelectedSequence] == NORMAL &&
+		this.ScannerChaser[this.SelectedSequence] &&
+		this.SelectedType == "scanner" &&
+		this.SelectButtonPressed[this.SelectedSequence] {
+
+		if debug {
+			fmt.Printf("%d: We are a SCANNER, Shutter Chaser On- 2nd Press Shutter Chase Mode - Handle Step 2\n", this.SelectedSequence)
+		}
+
+		// Calculate the next mode.
+		this.SelectMode[this.SelectedSequence] = getNextMenuItem(this.SelectMode[this.SelectedSequence], this.ScannerChaser[this.SelectedSequence])
+
+		// Now display the selected mode.
+		displayMode(this.SelectMode[this.SelectedSequence], this, sequences, eventsForLaunchpad, guiButtons, commandChannels)
+
+		return
+	}
+
+	// 3rd Press Status Mode and not a scanner - we display the fixture status enable/invert/disable buttons.
+	// We're in Function mode, pressed twice. and we're in edit sequence color mode. and we're NOT a scanner.
+	if this.SelectMode[this.SelectedSequence] == FUNCTION &&
+		!this.SelectButtonPressed[this.SelectedSequence] &&
+		!this.ShowRGBColorPicker &&
+		this.SelectedType != "scanner" {
+
+		if debug {
+			fmt.Printf("%d: Handle 3 - Status Buttons on\n", this.SelectedSequence)
+		}
+
+		// Calculate the next mode.
+		this.SelectMode[this.SelectedSequence] = getNextMenuItem(this.SelectMode[this.SelectedSequence], this.ScannerChaser[this.SelectedSequence])
+
+		// Now display the selected mode.
+		displayMode(this.SelectMode[this.SelectedSequence], this, sequences, eventsForLaunchpad, guiButtons, commandChannels)
+
+		return
+	}
+
+	// 3rd Press Status Mode and we are scanner and the shutter chaser is running - we display the shutter chaser function buttons.
+	if this.SelectMode[this.SelectedSequence] == FUNCTION &&
+		this.ScannerChaser[this.SelectedSequence] &&
+		!this.ShowRGBColorPicker &&
+		this.SelectedType == "scanner" {
+
+		if debug {
+			fmt.Printf("%d: Handle Step 4 Shutter Chase Function buttons on\n", this.SelectedSequence)
+		}
+
+		// Calculate the next mode.
+		this.SelectMode[this.SelectedSequence] = getNextMenuItem(this.SelectMode[this.SelectedSequence], this.ScannerChaser[this.SelectedSequence])
+
+		// Now display the selected mode.
+		displayMode(this.SelectMode[this.SelectedSequence], this, sequences, eventsForLaunchpad, guiButtons, commandChannels)
+
+		return
+	}
+
+	// 4th Press Normal Mode - we head back to normal mode.
+	if this.SelectMode[this.SelectedSequence] == STATUS &&
+		!this.SelectButtonPressed[this.SelectedSequence] &&
+		!this.ShowRGBColorPicker {
+
+		if debug {
+			fmt.Printf("%d: Handle Step 5 - Normal Mode From Non Scanner, Function Bar off\n", this.SelectedSequence)
+		}
+
+		// Remember that we've preseed twice.
+		this.SelectButtonPressed[this.SelectedSequence] = true
+
+		// Calculate the next mode.
+		this.SelectMode[this.SelectedSequence] = getNextMenuItem(this.SelectMode[this.SelectedSequence], this.ScannerChaser[this.SelectedSequence])
+
+		// Now display the selected mode.
+		displayMode(this.SelectMode[this.SelectedSequence], this, sequences, eventsForLaunchpad, guiButtons, commandChannels)
+
+		return
+	}
+
+	// 4th Press Normal Mode and we are a scanner- we head fixture status mode.
+	if (this.SelectMode[this.SelectedSequence] == CHASER_FUNCTION || !this.ScannerChaser[this.SelectedSequence]) &&
+		!this.SelectButtonPressed[this.SelectedSequence] &&
+		!this.ShowRGBColorPicker &&
+		this.SelectedType == "scanner" {
+
+		if debug {
+			fmt.Printf("%d: Handle Step 6 Normal Mode, From  Scanner, Function Bar off, status buttons on\n", this.SelectedSequence)
+		}
+
+		// Calculate the next mode.
+		this.SelectMode[this.SelectedSequence] = getNextMenuItem(this.SelectMode[this.SelectedSequence], this.ScannerChaser[this.SelectedSequence])
+
+		// Now display the selected mode.
+		displayMode(this.SelectMode[this.SelectedSequence], this, sequences, eventsForLaunchpad, guiButtons, commandChannels)
+
+		return
+	}
+
+	if debug {
+		fmt.Printf("HANDLE: Sequence %d Nothing Handled  \n", this.TargetSequence)
+	}
+
+}
+
+func removeColorPicker(this *CurrentState, eventsForLaunchpad chan common.ALight, guiButtons chan common.ALight, commandChannels []chan common.Command) {
+
+	this.SelectButtonPressed[this.SelectedSequence] = false
+	this.SelectMode[this.SelectedSequence] = NORMAL
+	this.Functions[this.EditWhichStaticSequence][common.Function5_Color].State = false
+
+	// Clear the first three launchpad rows used by the color picker.
+	for y := 0; y < 3; y++ {
+		common.ClearSelectedRowOfButtons(y, eventsForLaunchpad, guiButtons)
+	}
+
+	// Show the static and switch settings.
+	cmd := common.Command{
+		Action: common.UnHide,
+	}
+
+	// Take account of the shutter chaser which should be shown if the chaser is running.
+	common.SendCommandToSequence(0, cmd, commandChannels)
+	common.SendCommandToSequence(1, cmd, commandChannels)
+	if !this.ScannerChaser[this.SelectedSequence] {
+		common.SendCommandToSequence(2, cmd, commandChannels)
+	} else {
+		common.SendCommandToSequence(4, cmd, commandChannels)
+	}
+
+}
+
+func displayMode(mode int, this *CurrentState, sequences []*common.Sequence, eventsForLaunchpad chan common.ALight, guiButtons chan common.ALight, commandChannels []chan common.Command) {
+
+	// Clear the buttons.
+	common.ClearSelectedRowOfButtons(this.SelectedSequence, eventsForLaunchpad, guiButtons)
+
+	if debug {
+		printMode(this)
+	}
+
+	// Hide any function keys.
+	hideAllFunctionKeys(this, sequences, eventsForLaunchpad, guiButtons, commandChannels)
+
+	// Tailor the top buttons to the sequence type.
+	common.ShowTopButtons(sequences[this.SelectedSequence].Type, eventsForLaunchpad, guiButtons)
+
+	// Tailor the bottom buttons to the sequence type.
+	common.ShowBottomButtons(sequences[this.SelectedSequence].Type, eventsForLaunchpad, guiButtons)
+
+	// Show this sequence running status in the start/stop button.
+	common.ShowRunningStatus(this.SelectedSequence, this.Running, eventsForLaunchpad, guiButtons)
+
+	// Update the status bar.
+	showStatusBar(this, sequences, guiButtons)
+
+	// Light the sequence selector button.
+	SequenceSelect(eventsForLaunchpad, guiButtons, this)
+
+	switch {
+
+	case mode == NORMAL:
+
+		if debug {
+			fmt.Printf("displayMode: NORMAL\n")
+		}
+
+		// If we have a shutter chaser running hide it.
+		if this.ScannerChaser[this.SelectedSequence] && this.SelectedType == "scanner" {
+			common.HideSequence(this.ChaserSequenceNumber, commandChannels)
+		}
+		// Reveal the selected sequence.
+		common.RevealSequence(this.SelectedSequence, commandChannels)
+
+		return
+
+	case mode == CHASER_DISPLAY:
+
+		if debug {
+			fmt.Printf("displayMode: CHASER_DISPLAY\n")
+		}
+		// Hide the selected sequence.
+		common.HideSequence(this.SelectedSequence, commandChannels)
+
+		// Reveal the shutter chaser.
+		//if this.ScannerChaser[this.SelectedSequence] && this.SelectedType == "scanner" {
+		common.RevealSequence(this.ChaserSequenceNumber, commandChannels)
+		//}
+
+		return
+
+	case mode == FUNCTION:
+
+		if debug {
+			fmt.Printf("displayMode: FUNCTION  Seq:%d Shutter Chaser is %t\n", this.SelectedSequence, this.ScannerChaser[this.SelectedSequence])
+		}
+		// If we have a shutter chaser running hide it.
+		//if this.ScannerChaser[this.SelectedSequence] && this.SelectedType == "scanner" {
+		common.HideSequence(this.ChaserSequenceNumber, commandChannels)
+		//}
+		// Hide the sequence.
+		common.HideSequence(this.SelectedSequence, commandChannels)
+
+		// Update the bottom buttons.
+		common.UpdateBottomButtons("rgb", guiButtons)
+		common.UpdateStatusBar(fmt.Sprintf("Speed %02d", this.Speed[this.ChaserSequenceNumber]), "speed", false, guiButtons)
+		common.UpdateStatusBar(fmt.Sprintf("Shift %02d", this.RGBShift[this.ChaserSequenceNumber]), "shift", false, guiButtons)
+		common.UpdateStatusBar(fmt.Sprintf("Size %02d", this.RGBSize[this.ChaserSequenceNumber]), "size", false, guiButtons)
+		common.UpdateStatusBar(fmt.Sprintf("Fade %02d", this.RGBFade[this.ChaserSequenceNumber]), "fade", false, guiButtons)
+
+		// Show the function buttons.
+		ShowFunctionButtons(this, eventsForLaunchpad, guiButtons)
+
+		return
+
+	case mode == CHASER_FUNCTION:
+
+		if debug {
+			fmt.Printf("displayMode: CHASER_FUNCTION\n")
+		}
+		// If we have a shutter chaser running hide it.
+		if this.ScannerChaser[this.SelectedSequence] && this.SelectedType == "scanner" {
+			common.HideSequence(this.ChaserSequenceNumber, commandChannels)
+		}
+		// Hide the normal sequence.
+		common.HideSequence(this.SelectedSequence, commandChannels)
+
+		// Update the labels.
+		common.LabelButton(0, 7, "Chase\nSpeed\nDown", guiButtons)
+		common.LabelButton(1, 7, "Chase\nSpeed\nUp", guiButtons)
+		common.UpdateStatusBar(fmt.Sprintf("Chase Speed %02d", this.Speed[this.ChaserSequenceNumber]), "speed", false, guiButtons)
+		common.LabelButton(2, 7, "Chase\nShift\nDown", guiButtons)
+		common.LabelButton(3, 7, "Chase\nShift\nUp", guiButtons)
+		common.LabelButton(4, 7, "Chase\nSize\nDown", guiButtons)
+		common.LabelButton(5, 7, "Chase\nSize\nUp", guiButtons)
+		common.LabelButton(6, 7, "Chase\nFade\nSoft", guiButtons)
+		common.LabelButton(7, 7, "Chase\nFade\nSharp", guiButtons)
+
+		// Show the chaser function buttons.
+		this.TargetSequence = this.ChaserSequenceNumber
+		ShowFunctionButtons(this, eventsForLaunchpad, guiButtons)
+
+		return
+
+	case mode == STATUS:
+
+		if debug {
+			fmt.Printf("displayMode: STATUS\n")
+		}
+		// If we're a scanner sequence and trying to display the status bar we don't want a shutter chaser in view.
+		if this.ScannerChaser[this.SelectedSequence] && this.SelectedType == "scanner" {
+			common.HideSequence(this.ChaserSequenceNumber, commandChannels)
+		}
+		// Hide the normal sequence.
+		common.HideSequence(this.SelectedSequence, commandChannels)
+
+		// Display the fixture status bar.
+		showFixtureStatus(this.TargetSequence, sequences[this.SelectedSequence].Number, sequences[this.SelectedSequence].NumberFixtures, this, eventsForLaunchpad, guiButtons, commandChannels)
+
+		return
+	}
+
+}
+
+func showStatusBar(this *CurrentState, sequences []*common.Sequence, guiButtons chan common.ALight) {
+
 	// Update the status bar
+	common.UpdateStatusBar(fmt.Sprintf("Speed %02d", this.Speed[this.TargetSequence]), "speed", false, guiButtons)
+
+	// Update the buttons: speed
+	common.UpdateBottomButtons(this.SelectedType, guiButtons)
+
 	if this.Strobe[this.SelectedSequence] {
 		common.UpdateStatusBar(fmt.Sprintf("Strobe %02d", this.StrobeSpeed[this.DisplaySequence]), "speed", false, guiButtons)
 	} else {
-		// Update status bar.
 		if this.Functions[this.SelectedSequence][common.Function8_Music_Trigger].State {
 			common.UpdateStatusBar("  MUSIC  ", "speed", false, guiButtons)
 		} else {
@@ -111,642 +463,40 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 		common.UpdateStatusBar("        ", "green", false, guiButtons)
 		common.UpdateStatusBar(fmt.Sprintf("Pan %02d", this.OffsetPan), "pan", false, guiButtons)
 	}
-
-	// Light the top buttons.
-	common.ShowTopButtons(sequences[this.DisplaySequence].Type, eventsForLaunchpad, guiButtons)
-
-	// Light the strobe button.
-	common.ShowStrobeButtonStatus(this.Strobe[this.DisplaySequence], eventsForLaunchpad, guiButtons)
-
-	// Light the start stop button.
-	common.ShowRunningStatus(this.DisplaySequence, this.Running, eventsForLaunchpad, guiButtons)
-
-	// 1st Press Select Sequence - This the first time we have pressed the select button.
-	// Simply select the selected sequence.
-	// But remember we have pressed this select button once.
-	if this.SelectMode[this.DisplaySequence] == NORMAL && !this.SelectButtonPressed[this.DisplaySequence] || // Normal mode and first time pressed.
-		// OR we're in the CHASER_DISPLAY mode with the chaser on and the DisplayChaserShortCut has fired
-		this.SelectMode[this.SelectedSequence] == CHASER_DISPLAY && this.ScannerChaser[this.SelectedSequence] && this.DisplayChaserShortCut {
-
-		if debug {
-			fmt.Printf("%d: Show Sequence - Handle Step 1\n", this.SelectedSequence)
-		}
-
-		// OK this is complicated,, but if we have switched on the shutter chaser from the scanner sequence function key 7 "Scanner Shutter Chase"
-		// We would at arrive at Step 2 below, where we would have switched the mode to CHASER_DISPLAY and force the display to show the shutter chaser.
-		// What we are doing here is using the DisplayChaserShortCut flag to detect that this has happened and force the next step in the select press sequence to
-		// go back to the NORMAL mode and resume the sequence of select presses to as described in the header of this Handle() function.
-		if this.DisplayChaserShortCut {
-			this.SelectMode[this.DisplaySequence] = NORMAL
-			// And now forget this ever happened. Well untill the next shortcut is called.
-			this.DisplayChaserShortCut = false
-		}
-
-		// Flash all static fixtures. Represents all fixtures selected.
-		if !this.SelectAllStaticFixtures && this.EditStaticColorsMode[this.DisplaySequence] && !this.EditColorPicker {
-			if debug {
-				fmt.Printf("%d: Select All\n", this.DisplaySequence)
-			}
-			this.SelectAllStaticFixtures = true
-			// Update all the fixtures so they will flash.
-			cmd := common.Command{
-				Action: common.UpdateFlashAllStaticColorButtons,
-				Args: []common.Arg{
-					{Name: "StaticFlash", Value: this.SelectAllStaticFixtures},
-				},
-			}
-			if this.SelectedType == "scanner" && this.ScannerChaser[this.DisplaySequence] {
-				common.SendCommandToSequence(this.ChaserSequenceNumber, cmd, commandChannels)
-			} else {
-				if this.TargetSequence != 2 {
-					common.SendCommandToSequence(this.TargetSequence, cmd, commandChannels)
-				}
-			}
-		}
-
-		// Assume everything else is off.
-		this.SelectButtonPressed[0] = false
-		this.SelectButtonPressed[1] = false
-		this.SelectButtonPressed[2] = false
-		this.SelectButtonPressed[3] = false
-
-		// Remember which select button has been pressed.
-		this.SelectButtonPressed[this.SelectedSequence] = true
-
-		// Turn off the color picker if set.
-		if this.EditColorPicker {
-			removeColorPicker(this, eventsForLaunchpad, guiButtons, commandChannels)
-			this.EditColorPicker = false
-
-			// Turn off function mode. Remove the function pads.
-			common.ClearSelectedRowOfButtons(this.SelectedSequence, eventsForLaunchpad, guiButtons)
-
-			// If the chaser is running, reveal it.
-			if this.ScannerChaser[this.SelectedSequence] && this.SelectedType == "scanner" && this.SelectMode[this.SelectedSequence] == CHASER_DISPLAY {
-				common.HideSequence(this.SelectedSequence, commandChannels)
-				common.RevealSequence(this.ChaserSequenceNumber, commandChannels)
-				this.SelectMode[this.SelectedSequence] = CHASER_DISPLAY
-			} else {
-				common.HideSequence(this.ChaserSequenceNumber, commandChannels)
-				// And reveal the sequence on the launchpad keys
-				common.RevealSequence(this.SelectedSequence, commandChannels)
-				this.SelectMode[this.SelectedSequence] = NORMAL
-			}
-		}
-
-		// Turn off any previous function or status bars.
-		for sequenceNumber := range sequences {
-			if this.SelectMode[sequenceNumber] == FUNCTION ||
-				this.SelectMode[sequenceNumber] == STATUS {
-				common.ClearSelectedRowOfButtons(sequenceNumber, eventsForLaunchpad, guiButtons)
-				// And reveal all the other sequence that isn't us.
-				if sequenceNumber != this.SelectedSequence {
-					if this.ScannerChaser[this.SelectedSequence] {
-						common.HideSequence(this.ChaserSequenceNumber, commandChannels)
-					}
-					common.RevealSequence(sequenceNumber, commandChannels)
-					// And turn off the function selected.
-					this.SelectMode[sequenceNumber] = NORMAL
-				}
-			}
-		}
-
-		if this.Functions[this.SelectedSequence][common.Function1_Pattern].State {
-			// Reset the pattern function key.
-			this.Functions[this.SelectedSequence][common.Function1_Pattern].State = false
-
-			// Clear the pattern function keys
-			ClearPatternSelectionButtons(this.SelectedSequence, *sequences[this.SelectedSequence], eventsForLaunchpad, guiButtons)
-
-			// And reveal the sequence.
-			if this.ScannerChaser[this.SelectedSequence] {
-				common.HideSequence(this.ChaserSequenceNumber, commandChannels)
-			}
-			common.RevealSequence(this.SelectedSequence, commandChannels)
-
-			// Editing pattern is over for this sequence.
-			this.EditPatternMode = false
-
-			// Clear buttons and remove any labels.
-			common.ClearSelectedRowOfButtons(this.SelectedSequence, eventsForLaunchpad, guiButtons)
-		}
-
-		if this.SelectMode[this.SelectedSequence] == NORMAL &&
-			this.Functions[this.EditWhichStaticSequence][common.Function5_Color].State &&
-			this.EditSequenceColorPickerMode {
-
-			fmt.Printf("Color Edit Mode Off for sequence %d\n", this.SelectedSequence)
-
-			// Reset the color function key.
-			this.Functions[this.EditWhichStaticSequence][common.Function5_Color].State = false
-
-			// And reveal the sequence on the launchpad keys
-			// and hide the shutter chaser.
-			if this.ScannerChaser[this.SelectedSequence] && this.SelectedType == "scanner" {
-				common.HideSequence(this.ChaserSequenceNumber, commandChannels)
-			}
-			common.RevealSequence(this.SelectedSequence, commandChannels)
-
-			// Turn off the function mode flag.
-			this.SelectMode[this.SelectedSequence] = NORMAL
-
-			// Now forget we pressed twice and start again.
-			this.SelectButtonPressed[this.SelectedSequence] = true
-
-			common.HideColorSelectionButtons(this.SelectedSequence, *sequences[this.SelectedSequence], eventsForLaunchpad, guiButtons)
-
-		}
-
-		// Tailor the top buttons to the sequence type.
-		common.ShowTopButtons(sequences[this.SelectedSequence].Type, eventsForLaunchpad, guiButtons)
-
-		// Tailor the bottom buttons to the sequence type.
-		common.ShowBottomButtons(sequences[this.SelectedSequence].Type, eventsForLaunchpad, guiButtons)
-
-		// Show this sequence running status in the start/stop button.
-		common.ShowRunningStatus(this.SelectedSequence, this.Running, eventsForLaunchpad, guiButtons)
-
-		// Clear the select unless we're in static mode for this sequence.
-		if !this.EditStaticColorsMode[this.SelectedSequence] {
-			common.ClearSelectedRowOfButtons(this.SelectedSequence, eventsForLaunchpad, guiButtons)
-		}
-
-		// Now select the correct exit mode for scanner sequences.
-		if this.ScannerChaser[this.SelectedSequence] && this.SelectedType == "scanner" {
-			if this.SelectMode[this.SelectedSequence] == NORMAL {
-				common.HideSequence(this.ChaserSequenceNumber, commandChannels)
-				common.RevealSequence(this.SelectedSequence, commandChannels)
-			}
-		}
-		if debug {
-			printMode(this)
-		}
-		// Light the sequence selector button.
-		SequenceSelect(eventsForLaunchpad, guiButtons, this)
-		return
-	}
-
-	// First option of the 2nd Press in scanner mode go into Shutter Chaser Mode for this sequence.
-	// We're in Normal mode, We've Pressed twice and the scanner chaser is on and we're a scanner sequence.
-	// Or the DisplayChaserShortCut has fired.
-	if (this.SelectMode[this.SelectedSequence] == NORMAL &&
-		this.ScannerChaser[this.SelectedSequence] &&
-		this.SelectedType == "scanner" &&
-		this.SelectButtonPressed[this.SelectedSequence]) || this.DisplayChaserShortCut {
-
-		if debug {
-			fmt.Printf("%d: We are a SCANNER - 2nd Press Shutter Chase Mode - Handle Step 2\n", this.SelectedSequence)
-		}
-
-		// Set function mode. And take note if we arrived using the shortcut.
-		if this.DisplayChaserShortCut {
-			if debug {
-				fmt.Printf("%d: Chaser Display entered via DisplayChaserShortCut\n", this.SelectedSequence)
-			}
-			this.SelectButtonPressed[this.SelectedSequence] = false
-		}
-
-		// Update the bottom buttons.
-		common.UpdateBottomButtons("rgb", guiButtons)
-		common.UpdateStatusBar(fmt.Sprintf("Speed %02d", this.Speed[this.ChaserSequenceNumber]), "speed", false, guiButtons)
-		common.UpdateStatusBar(fmt.Sprintf("Shift %02d", this.RGBShift[this.ChaserSequenceNumber]), "shift", false, guiButtons)
-		common.UpdateStatusBar(fmt.Sprintf("Size %02d", this.RGBSize[this.ChaserSequenceNumber]), "size", false, guiButtons)
-		common.UpdateStatusBar(fmt.Sprintf("Fade %02d", this.RGBFade[this.ChaserSequenceNumber]), "fade", false, guiButtons)
-
-		// Set the Shutter Chaser mode.
-		this.SelectMode[this.SelectedSequence] = CHASER_DISPLAY
-
-		// Hide the rotating sequence.
-		common.HideSequence(this.SelectedSequence, commandChannels)
-
-		// Clear the sequence.
-		common.ClearSelectedRowOfButtons(this.SelectedSequence, eventsForLaunchpad, guiButtons)
-
-		// And show the chaser sequence.
-		common.RevealSequence(this.ChaserSequenceNumber, commandChannels)
-
-		if debug {
-			printMode(this)
-		}
-
-		// Light the sequence selector button.
-		SequenceSelect(eventsForLaunchpad, guiButtons, this)
-		return
-	}
-
-	// Second option of the 2nd Press in rgb mode same select button go into Function Mode for this sequence.
-	// We're in Normal mode, We've Pressed twice. we're a rgb sequence.
-	// Or
-	// We're in Normal mode, We've Pressed twice. but the scanner chaser is off
-	// Or
-	// We're in Chaser Display mode. and scanner sequence.
-	if (this.SelectMode[this.SelectedSequence] == NORMAL && this.SelectedType == "rgb") ||
-		(this.SelectMode[this.SelectedSequence] == NORMAL && !this.ScannerChaser[this.SelectedSequence]) ||
-		(this.SelectMode[this.SelectedSequence] == CHASER_DISPLAY && this.SelectedType == "scanner") {
-
-		if debug {
-			fmt.Printf("%d: 2nd Press Function Bar Mode - Handle Step 2\n", this.SelectedSequence)
-		}
-
-		// Set function mode.
-		this.SelectMode[this.SelectedSequence] = FUNCTION
-
-		// Toggle the select all static fixuure off.
-		if this.SelectAllStaticFixtures {
-			this.SelectAllStaticFixtures = false
-			// Update all the fixtures so they will stop flashing.
-			cmd := common.Command{
-				Action: common.UpdateFlashAllStaticColorButtons,
-				Args: []common.Arg{
-					{Name: "StaticFlash", Value: this.SelectAllStaticFixtures},
-				},
-			}
-			common.SendCommandToSequence(this.TargetSequence, cmd, commandChannels)
-		}
-
-		// And hide the sequence so we can only see the function buttons.
-		common.HideSequence(this.SelectedSequence, commandChannels)
-
-		// If the shutter chaser is running, hide it.
-		if this.ScannerChaser[this.SelectedSequence] && this.SelectedType == "scanner" {
-			common.HideSequence(this.ChaserSequenceNumber, commandChannels)
-		}
-
-		// Turn off any previous function bars.
-		for sequenceNumber := range sequences {
-			if this.SelectMode[sequenceNumber] == FUNCTION {
-				common.ClearSelectedRowOfButtons(sequenceNumber, eventsForLaunchpad, guiButtons)
-				// And reveal all the other sequence that isn't us.
-				if sequenceNumber != this.SelectedSequence {
-					common.RevealSequence(sequenceNumber, commandChannels)
-					// And turn off the function selected.
-					this.SelectMode[sequenceNumber] = NORMAL
-				}
-			}
-		}
-
-		// Clear the buttons.
-		common.ClearSelectedRowOfButtons(this.SelectedSequence, eventsForLaunchpad, guiButtons)
-
-		// If we're a scanner sequence and trying to display the function bar we don't want a shutter chaser in view.
-		if !this.ScannerChaser[this.SelectedSequence] && this.SelectedType == "scanner" {
-			common.HideSequence(this.ChaserSequenceNumber, commandChannels)
-		}
-
-		// Show the function buttons.
-		ShowFunctionButtons(this, eventsForLaunchpad, guiButtons)
-
-		// Now forget we pressed twice and start again.
-		this.SelectButtonPressed[this.SelectedSequence] = false
-
-		if debug {
-			printMode(this)
-		}
-
-		// Light the sequence selector button.
-		SequenceSelect(eventsForLaunchpad, guiButtons, this)
-		return
-	}
-
-	// 3rd Press Status Mode and not a scanner - we display the fixture status enable/invert/disable buttons.
-	// We're in Function mode, pressed twice. and we're in edit sequence color mode. and we're NOT a scanner.
-	if this.SelectMode[this.SelectedSequence] == FUNCTION &&
-		!this.SelectButtonPressed[this.SelectedSequence] &&
-		!this.EditSequenceColorPickerMode &&
-		this.SelectedType != "scanner" {
-
-		if debug {
-			fmt.Printf("%d: Handle 3 - Status Buttons on\n", this.SelectedSequence)
-		}
-
-		// Turn on status mode
-		this.SelectMode[this.SelectedSequence] = STATUS
-
-		// If the chase is running, hide it.
-		if this.ScannerChaser[this.SelectedSequence] && this.SelectedType == "scanner" {
-			common.HideSequence(this.ChaserSequenceNumber, commandChannels)
-		}
-
-		// Remove the function pads.
-		common.ClearSelectedRowOfButtons(this.SelectedSequence, eventsForLaunchpad, guiButtons)
-
-		// Show the Fixture Status Buttons.
-		showFixtureStatus(this.TargetSequence, sequences[this.SelectedSequence].Number, sequences[this.SelectedSequence].NumberFixtures, this, eventsForLaunchpad, guiButtons, commandChannels)
-
-		if debug {
-			printMode(this)
-		}
-
-		// Light the sequence selector button.
-		SequenceSelect(eventsForLaunchpad, guiButtons, this)
-		return
-	}
-
-	// 3rd Press Status Mode and we are scanner and the shutter chaser is running - we display the shutter chaser function buttons.
-	if this.SelectMode[this.SelectedSequence] == FUNCTION &&
-		this.ScannerChaser[this.SelectedSequence] &&
-		!this.SelectButtonPressed[this.SelectedSequence] &&
-		!this.EditSequenceColorPickerMode &&
-		this.SelectedType == "scanner" {
-
-		if debug {
-			fmt.Printf("%d: Handle Step 4 Shutter Chase Function buttons on\n", this.SelectedSequence)
-		}
-
-		// Turn on shutter chaser mode.
-		this.SelectMode[this.SelectedSequence] = CHASER_FUNCTION
-
-		// Update the buttons: speed
-		common.LabelButton(0, 7, "Chase\nSpeed\nDown", guiButtons)
-		common.LabelButton(1, 7, "Chase\nSpeed\nUp", guiButtons)
-
-		// Update the status bar
-		common.UpdateStatusBar(fmt.Sprintf("Chase Speed %02d", this.Speed[this.ChaserSequenceNumber]), "speed", false, guiButtons)
-
-		common.LabelButton(2, 7, "Chase\nShift\nDown", guiButtons)
-		common.LabelButton(3, 7, "Chase\nShift\nUp", guiButtons)
-
-		common.LabelButton(4, 7, "Chase\nSize\nDown", guiButtons)
-		common.LabelButton(5, 7, "Chase\nSize\nUp", guiButtons)
-
-		common.LabelButton(6, 7, "Chase\nFade\nSoft", guiButtons)
-		common.LabelButton(7, 7, "Chase\nFade\nSharp", guiButtons)
-
-		// If the chase is running, hide it.
-		if this.ScannerChaser[this.SelectedSequence] && this.SelectedType == "scanner" {
-			common.HideSequence(this.ChaserSequenceNumber, commandChannels)
-		}
-
-		// Remove the function pads.
-		common.ClearSelectedRowOfButtons(this.DisplaySequence, eventsForLaunchpad, guiButtons)
-
-		this.TargetSequence = this.ChaserSequenceNumber
-
-		// Show the function buttons.
-		ShowFunctionButtons(this, eventsForLaunchpad, guiButtons)
-
-		if debug {
-			printMode(this)
-		}
-
-		// Light the sequence selector button.
-		SequenceSelect(eventsForLaunchpad, guiButtons, this)
-		return
-	}
-
-	// 4th Press Normal Mode - we head back to normal mode.
-	if this.SelectMode[this.SelectedSequence] == STATUS &&
-		!this.SelectButtonPressed[this.SelectedSequence] &&
-		!this.EditSequenceColorPickerMode {
-
-		if debug {
-			fmt.Printf("%d: Handle Step 5 - Normal Mode From Non Scanner, Function Bar off\n", this.SelectedSequence)
-		}
-
-		// Turn off function mode.
-		this.SelectMode[this.SelectedSequence] = NORMAL
-
-		// Remove the status buttons.
-		common.ClearSelectedRowOfButtons(this.SelectedSequence, eventsForLaunchpad, guiButtons)
-
-		// We're in Edit Pattern Mode.
-		if this.Functions[this.SelectedSequence][common.Function1_Pattern].State {
-			if debug {
-				fmt.Printf("Show Pattern Selection Buttons\n")
-			}
-			this.EditPatternMode = true
-			common.HideSequence(this.SelectedSequence, commandChannels)
-			ShowPatternSelectionButtons(this, sequences[this.SelectedSequence].Master, *sequences[this.SelectedSequence], this.DisplaySequence, eventsForLaunchpad, guiButtons)
-			// Light the sequence selector button.
-			SequenceSelect(eventsForLaunchpad, guiButtons, this)
-			return
-		}
-
-		// We're in RGB Color Selection Mode.
-		if this.SelectedType == "rgb" && this.Functions[this.EditWhichStaticSequence][common.Function5_Color].State {
-			if debug {
-				fmt.Printf("Show RGB Sequence Color Selection Buttons\n")
-			}
-			// Turn off the color selection function key.
-			this.Functions[this.EditWhichStaticSequence][common.Function5_Color].State = false
-			// Set the colors.
-			sequences[this.EditWhichStaticSequence].CurrentColors = sequences[this.EditWhichStaticSequence].SequenceColors
-			// Show the colors
-			ShowRGBColorPicker(this.MasterBrightness, *sequences[this.EditWhichStaticSequence], this.DisplaySequence, eventsForLaunchpad, guiButtons, commandChannels)
-			// Light the sequence selector button.
-			SequenceSelect(eventsForLaunchpad, guiButtons, this)
-			return
-		}
-
-		// We're in RGB Static Color Mode.
-		var static bool
-		// Check all sequences to see if one is static.
-		for sequenceNumber, isStatic := range this.EditStaticColorsMode {
-			if isStatic {
-				if debug {
-					fmt.Printf("Show RGB Static Colors for sequence %d\n", sequenceNumber)
-				}
-				//common.SetMode(sequenceNumber, commandChannels, "Static")
-				common.RevealSequence(sequenceNumber, commandChannels)
-				//this.EditStaticColorsMode = false
-				static = true
-			}
-		}
-		if static {
-			// Light the sequence selector button.
-			SequenceSelect(eventsForLaunchpad, guiButtons, this)
-			if debug {
-				printMode(this)
-			}
-			// Turn off the function mode flag.
-			this.SelectMode[this.SelectedSequence] = NORMAL
-			// If the chase is running, hide it.
-			if this.ScannerChaser[this.SelectedSequence] && this.SelectedType == "scanner" {
-				if debug {
-					fmt.Printf("%d: Hide Sequence\n", this.ChaserSequenceNumber)
-				}
-				common.HideSequence(this.ChaserSequenceNumber, commandChannels)
-			}
-			// Remember that we've preseed twice.
-			this.SelectButtonPressed[this.SelectedSequence] = true
-			return
-		}
-
-		// We're in Scanner Gobo Selection Mode.
-		if this.Functions[this.SelectedSequence][common.Function6_Static_Gobo].State &&
-			!this.EditStaticColorsMode[this.EditWhichStaticSequence] &&
-			sequences[this.SelectedSequence].Type == "scanner" {
-			this.Functions[this.SelectedSequence][common.Function6_Static_Gobo].State = false
-			this.EditGoboSelectionMode = false
-		}
-
-		// Allow us to exit the pattern select mode without setting a pattern.
-		if this.EditPatternMode {
-			this.EditPatternMode = false
-		}
-
-		// Else reveal the sequence on the launchpad keys
-		if debug {
-			fmt.Printf("%d: Reveal Sequence\n", this.SelectedSequence)
-		}
-		common.RevealSequence(this.SelectedSequence, commandChannels)
-
-		// If the chase is running, reveal it. But only if we're in CHASER_DISPLAY mode.
-		if this.ScannerChaser[this.SelectedSequence] && this.SelectedType == "scanner" && this.SelectMode[this.SelectedSequence] == CHASER_DISPLAY {
-			if debug {
-				fmt.Printf("%d: Reveal Sequence\n", this.ChaserSequenceNumber)
-			}
-			common.RevealSequence(this.ChaserSequenceNumber, commandChannels)
-		}
-
-		// Turn off the function mode flag.
-		this.SelectMode[this.SelectedSequence] = NORMAL
-		// Remember that we've preseed twice.
-		this.SelectButtonPressed[this.SelectedSequence] = true
-
-		if debug {
-			printMode(this)
-		}
-		// Light the sequence selector button.
-		SequenceSelect(eventsForLaunchpad, guiButtons, this)
-		return
-	}
-
-	// 4th Press Normal Mode and we are a scanner- we head fixture status mode.
-	if (this.SelectMode[this.SelectedSequence] == CHASER_FUNCTION || !this.ScannerChaser[this.SelectedSequence]) &&
-		!this.SelectButtonPressed[this.SelectedSequence] &&
-		!this.EditSequenceColorPickerMode &&
-		this.SelectedType == "scanner" {
-
-		if debug {
-			fmt.Printf("%d: Handle Step 6 Normal Mode, From  Scanner, Function Bar off, status buttons on\n", this.SelectedSequence)
-		}
-
-		// Turn on status mode
-		this.SelectMode[this.SelectedSequence] = STATUS
-
-		// Update the status bar
-		common.UpdateStatusBar(fmt.Sprintf("Speed %02d", this.Speed[this.TargetSequence]), "speed", false, guiButtons)
-
-		// Update the buttons: speed
-		common.UpdateBottomButtons(this.SelectedType, guiButtons)
-
-		// If the chase is running, hide it.
-		if this.ScannerChaser[this.SelectedSequence] && this.SelectedType == "scanner" {
-			common.HideSequence(this.ChaserSequenceNumber, commandChannels)
-		}
-
-		// Turn off the edit sequence colors button.
-		if this.EditSequenceColorPickerMode {
-			this.EditSequenceColorPickerMode = false
-			this.Functions[this.EditWhichStaticSequence][common.Function5_Color].State = false
-		}
-
-		// Remove the function pads.
-		common.ClearSelectedRowOfButtons(this.SelectedSequence, eventsForLaunchpad, guiButtons)
-
-		// Show the Fixture Status Buttons.
-		showFixtureStatus(this.TargetSequence, sequences[this.SelectedSequence].Number, sequences[this.SelectedSequence].NumberFixtures, this, eventsForLaunchpad, guiButtons, commandChannels)
-
-		if debug {
-			printMode(this)
-		}
-		// Light the sequence selector button.
-		SequenceSelect(eventsForLaunchpad, guiButtons, this)
-		return
-	}
-
-	// Are we in function mode ?
-	if this.SelectMode[this.SelectedSequence] == FUNCTION || this.SelectMode[this.SelectedSequence] == CHASER_FUNCTION {
-		if debug {
-			fmt.Printf("HANDLE %d: Handle 7 - Back to NORMAL mode.\n", this.SelectedSequence)
-		}
-		// Turn off function mode. Remove the function pads.
-		common.ClearSelectedRowOfButtons(this.SelectedSequence, eventsForLaunchpad, guiButtons)
-
-		// And reveal the sequence on the launchpad keys
-		common.RevealSequence(this.SelectedSequence, commandChannels)
-
-		// If the chaser is running, reveal it.
-		if this.ScannerChaser[this.SelectedSequence] && this.SelectedType == "scanner" {
-			common.RevealSequence(this.ChaserSequenceNumber, commandChannels)
-		}
-
-		// Now select the correct exit mode based on which mode we came in on.
-		if this.SelectMode[this.SelectedSequence] == FUNCTION {
-			this.SelectMode[this.SelectedSequence] = NORMAL
-		}
-		if this.SelectMode[this.SelectedSequence] == CHASER_FUNCTION {
-			this.SelectMode[this.SelectedSequence] = CHASER_DISPLAY
-		}
-
-		// Turn off the edit sequence colors button.
-		if this.EditSequenceColorPickerMode {
-			removeColorPicker(this, eventsForLaunchpad, guiButtons, commandChannels)
-			// If the Selected Color has come back as empty this means we didn't select any colors.
-			// So restore the colors that were already there.
-			if debug {
-				fmt.Printf("sequences[%d].SequenceColors %+v\n", this.SelectedSequence, sequences[this.SelectedSequence].SequenceColors)
-			}
-			if len(sequences[this.SelectedSequence].SequenceColors) == 0 {
-				if debug {
-					fmt.Printf("Restore Sequence Colors\n")
-				}
-				sequences[this.SelectedSequence].SequenceColors = this.SavedSequenceColors[this.SelectedSequence]
-				if debug {
-					fmt.Printf("Now set to ----> sequences[%d].SequenceColors %+v\n", this.SelectedSequence, sequences[this.SelectedSequence].SequenceColors)
-				}
-				// Tell the sequence that we have restored the colors.
-				cmd := common.Command{
-					Action: common.UpdateSequenceColors,
-					Args: []common.Arg{
-						{Name: "Colors", Value: sequences[this.SelectedSequence].SequenceColors},
-					},
-				}
-				common.SendCommandToSequence(this.SelectedSequence, cmd, commandChannels)
-			}
-		}
-
-		// Now forget we pressed twice and start again.
-		this.SelectButtonPressed[this.SelectedSequence] = false
-
-		if debug {
-			printMode(this)
-		}
-		// Light the sequence selector button.
-		SequenceSelect(eventsForLaunchpad, guiButtons, this)
-		return
-	}
-
-	if debug {
-		fmt.Printf("HANDLE: Sequence %d Nothing Handled  \n", this.TargetSequence)
-	}
-
 }
 
-func removeColorPicker(this *CurrentState, eventsForLaunchpad chan common.ALight, guiButtons chan common.ALight, commandChannels []chan common.Command) {
+func hideAllFunctionKeys(this *CurrentState, sequences []*common.Sequence, eventsForLaunchPad chan common.ALight, guiButtons chan common.ALight, commandChannels []chan common.Command) {
 
-	this.SelectButtonPressed[this.SelectedSequence] = false
-	this.SelectMode[this.SelectedSequence] = NORMAL
-	this.Functions[this.EditWhichStaticSequence][common.Function5_Color].State = false
-
-	// Clear the first three launchpad rows used by the color picker.
-	for y := 0; y < 3; y++ {
-		common.ClearSelectedRowOfButtons(y, eventsForLaunchpad, guiButtons)
+	for sequenceNumber := range sequences {
+		if this.SelectMode[sequenceNumber] == FUNCTION {
+			common.ClearSelectedRowOfButtons(sequenceNumber, eventsForLaunchPad, guiButtons)
+			// And reveal all the other sequence that isn't us.
+			if sequenceNumber != this.SelectedSequence {
+				// And turn off the function selected.
+				this.SelectMode[sequenceNumber] = NORMAL
+				displayMode(NORMAL, this, sequences, eventsForLaunchPad, guiButtons, commandChannels)
+			}
+		}
 	}
+}
 
-	// Show the static and switch settings.
-	cmd := common.Command{
-		Action: common.UnHide,
+func printHandleDebug(this *CurrentState) {
+	fmt.Printf("HANDLE: this.Type = %s \n", this.SelectedType)
+	for functionNumber := 0; functionNumber < 8; functionNumber++ {
+		state := this.Functions[this.TargetSequence][functionNumber]
+		fmt.Printf("%d function %d state %+v\n", this.TargetSequence, functionNumber, state.State)
 	}
+	fmt.Printf("HANDLE:  SEQ: %d this.ScannerChaser running %t \n", this.DisplaySequence, this.ScannerChaser[this.DisplaySequence])
 
-	// This doesn't take account of the shutter chaser which should be shown if the chaser is running.
-	common.SendCommandToSequence(0, cmd, commandChannels)
-	common.SendCommandToSequence(1, cmd, commandChannels)
-	if !this.ScannerChaser[this.SelectedSequence] {
-		common.SendCommandToSequence(2, cmd, commandChannels)
-	} else {
-		common.SendCommandToSequence(4, cmd, commandChannels)
-	}
+	fmt.Printf("================== WHAT SELECT MODE =================\n")
+	fmt.Printf("HANDLE: this.SelectButtonPressed[%d] = %t \n", this.TargetSequence, this.SelectButtonPressed[this.TargetSequence])
+	printMode(this)
 
+	fmt.Printf("================== WHAT EDIT MODES =================\n")
+	fmt.Printf("HANDLE: this.ShowRGBColorPicker[%d] = %t \n", this.TargetSequence, this.ShowRGBColorPicker)
+	fmt.Printf("HANDLE: this.ShowStaticColorPicker[%d] = %t \n", this.TargetSequence, this.ShowStaticColorPicker)
+	fmt.Printf("HANDLE: this.EditStaticColorsMode[%d] = %t \n", this.TargetSequence, this.EditStaticColorsMode)
+	fmt.Printf("HANDLE: this.EditGoboSelectionMode[%d] = %t \n", this.TargetSequence, this.EditGoboSelectionMode)
+	fmt.Printf("HANDLE: this.EditPatternMode[%d] = %t \n", this.TargetSequence, this.EditPatternMode)
+	fmt.Printf("===============================================\n")
 }

--- a/pkg/buttons/handle.go
+++ b/pkg/buttons/handle.go
@@ -130,19 +130,6 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 			fmt.Printf("%d: Show Sequence - Handle Step 1\n", this.SelectedSequence)
 		}
 
-		// Set all static fixures to all. So we can set a static color for all fixtures.
-		if this.EditStaticColorsMode[this.DisplaySequence] {
-			this.SelectAllStaticFixtures = true
-
-			cmd := common.Command{
-				Action: common.UpdateFlashAllStaticColorButtons,
-				Args: []common.Arg{
-					{Name: "Flash", Value: true},
-				},
-			}
-			common.SendCommandToSequence(this.SelectedSequence, cmd, commandChannels)
-		}
-
 		// Assume everything else is off.
 		this.SelectButtonPressed[0] = false
 		this.SelectButtonPressed[1] = false
@@ -162,6 +149,22 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 
 		// Remember which select button has been pressed.
 		this.SelectButtonPressed[this.SelectedSequence] = true
+
+		// Set all static fixures to all. So we can set a static color for all fixtures.
+		if !this.SelectAllStaticFixtures && this.EditStaticColorsMode[this.DisplaySequence] && !this.ShowStaticColorPicker && !this.Loading {
+			if debug {
+				fmt.Printf("%d: Select All\n", this.DisplaySequence)
+			}
+			this.SelectAllStaticFixtures = true
+			// Update all the fixtures so they will flash.
+			cmd := common.Command{
+				Action: common.UpdateFlashAllStaticColorButtons,
+				Args: []common.Arg{
+					{Name: "StaticFlash", Value: this.SelectAllStaticFixtures},
+				},
+			}
+			common.SendCommandToSequence(this.TargetSequence, cmd, commandChannels)
+		}
 
 		// Now display the selected mode.
 		displayMode(this.SelectMode[this.SelectedSequence], this, sequences, eventsForLaunchpad, guiButtons, commandChannels)
@@ -183,18 +186,17 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 			fmt.Printf("%d: 2nd Press Function Bar Mode - Handle Step 2\n", this.SelectedSequence)
 		}
 
-		// Turn off the all static colors flag.
-		if this.EditStaticColorsMode[this.DisplaySequence] && this.SelectAllStaticFixtures {
+		// Toggle the select all static fixuure off.
+		if this.SelectAllStaticFixtures {
 			this.SelectAllStaticFixtures = false
-			this.SelectButtonPressed[this.DisplaySequence] = false
-
+			// Update all the fixtures so they will stop flashing.
 			cmd := common.Command{
 				Action: common.UpdateFlashAllStaticColorButtons,
 				Args: []common.Arg{
-					{Name: "Flash", Value: false},
+					{Name: "StaticFlash", Value: this.SelectAllStaticFixtures},
 				},
 			}
-			common.SendCommandToSequence(this.SelectedSequence, cmd, commandChannels)
+			common.SendCommandToSequence(this.TargetSequence, cmd, commandChannels)
 		}
 
 		// Calculate the next mode.

--- a/pkg/buttons/handle.go
+++ b/pkg/buttons/handle.go
@@ -7,34 +7,35 @@ import (
 	"github.com/dhowlett99/dmxlights/pkg/sequence"
 )
 
-//	+-------------------+
-//	|       NORMAL      |
-//	+-------------------+
-//	    |            |
-//	    |            | If Scanner
-//	    V            V
-//	    |       +-------------------+
-//	    |       |  CHASER DISPLAY   |
-//	    |       +-------------------+
-//	    V            |
-//	+-------------------+
-//	|     FUNCTION      |
-//	+-------------------+
-//	    |            | If Scanner
-//	    V            V
-//	    |       +-------------------+
-//	    |       |  CHASER FUNCTIONS |
-//	    |       +-------------------+
-//	    |		     |
-//	    V			 V
-//	 +-------------------+
-//	 |  FIXTURE STATUS   |
-//	 +-------------------+
-//	          |
-//	          V
-//	 +-------------------+
-//	 |       NORMAL      |
-//	 +-------------------+
+//		+-------------------+
+//		|       NORMAL      |
+//		+-------------------+
+//		    |            |
+//		    |            | If Scanner
+//	     |            | or if the DisplayChaserShortCut is set.
+//		    V            V
+//		    |       +-------------------+
+//		    |       |  CHASER DISPLAY   |
+//		    |       +-------------------+
+//		    V            |
+//		+-------------------+
+//		|     FUNCTION      |
+//		+-------------------+
+//		    |            | If Scanner
+//		    V            V
+//		    |       +-------------------+
+//		    |       |  CHASER FUNCTIONS |
+//		    |       +-------------------+
+//		    |		     |
+//		    V			 V
+//		 +-------------------+
+//		 |  FIXTURE STATUS   |
+//		 +-------------------+
+//		          |
+//		          V
+//		 +-------------------+
+//		 |       NORMAL      |
+//		 +-------------------+
 //
 // HandleSelect - Runs when you press a select button to select a sequence.
 func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLaunchpad chan common.ALight,

--- a/pkg/buttons/handle.go
+++ b/pkg/buttons/handle.go
@@ -340,7 +340,7 @@ func displayMode(sequenceNumber int, mode int, this *CurrentState, sequences []*
 			this.SelectAllStaticFixtures = false
 
 			// Stop the flash of the static buttons,
-			flashwStaticButtons(this.ChaserSequenceNumber, false, commandChannels)
+			flashwStaticButtons(sequenceNumber, false, commandChannels)
 			this.StaticFlashing[sequenceNumber] = false
 		}
 

--- a/pkg/buttons/handle.go
+++ b/pkg/buttons/handle.go
@@ -64,7 +64,7 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 
 		fmt.Printf("================== WHAT EDIT MODES =================\n")
 		fmt.Printf("HANDLE: this.DisplayChaserShortCut = %t \n", this.DisplayChaserShortCut)
-		fmt.Printf("HANDLE: this.EditSequenceColorsMode[%d] = %t \n", this.TargetSequence, this.EditSequenceColorsMode)
+		fmt.Printf("HANDLE: this.EditSequenceColorPickerMode[%d] = %t \n", this.TargetSequence, this.EditSequenceColorPickerMode)
 		fmt.Printf("HANDLE: this.EditStaticColorsMode[%d] = %t \n", this.TargetSequence, this.EditStaticColorsMode)
 		fmt.Printf("HANDLE: this.EditGoboSelectionMode[%d] = %t \n", this.TargetSequence, this.EditGoboSelectionMode)
 		fmt.Printf("HANDLE: this.EditPatternMode[%d] = %t \n", this.TargetSequence, this.EditPatternMode)
@@ -227,7 +227,7 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 
 		if this.SelectMode[this.SelectedSequence] == NORMAL &&
 			this.Functions[this.EditWhichSequence][common.Function5_Color].State &&
-			this.EditSequenceColorsMode {
+			this.EditSequenceColorPickerMode {
 
 			fmt.Printf("Color Edit Mode Off for sequence %d\n", this.SelectedSequence)
 
@@ -406,7 +406,7 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 	// We're in Function mode, pressed twice. and we're in edit sequence color mode. and we're NOT a scanner.
 	if this.SelectMode[this.SelectedSequence] == FUNCTION &&
 		!this.SelectButtonPressed[this.SelectedSequence] &&
-		!this.EditSequenceColorsMode &&
+		!this.EditSequenceColorPickerMode &&
 		this.SelectedType != "scanner" {
 
 		if debug {
@@ -440,7 +440,7 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 	if this.SelectMode[this.SelectedSequence] == FUNCTION &&
 		this.ScannerChaser[this.SelectedSequence] &&
 		!this.SelectButtonPressed[this.SelectedSequence] &&
-		!this.EditSequenceColorsMode &&
+		!this.EditSequenceColorPickerMode &&
 		this.SelectedType == "scanner" {
 
 		if debug {
@@ -491,7 +491,7 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 	// 4th Press Normal Mode - we head back to normal mode.
 	if this.SelectMode[this.SelectedSequence] == STATUS &&
 		!this.SelectButtonPressed[this.SelectedSequence] &&
-		!this.EditSequenceColorsMode {
+		!this.EditSequenceColorPickerMode {
 
 		if debug {
 			fmt.Printf("%d: Handle Step 5 - Normal Mode From Non Scanner, Function Bar off\n", this.SelectedSequence)
@@ -595,7 +595,7 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 	// 4th Press Normal Mode and we are a scanner- we head fixture status mode.
 	if (this.SelectMode[this.SelectedSequence] == CHASER_FUNCTION || !this.ScannerChaser[this.SelectedSequence]) &&
 		!this.SelectButtonPressed[this.SelectedSequence] &&
-		!this.EditSequenceColorsMode &&
+		!this.EditSequenceColorPickerMode &&
 		this.SelectedType == "scanner" {
 
 		if debug {
@@ -617,8 +617,8 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 		}
 
 		// Turn off the edit sequence colors button.
-		if this.EditSequenceColorsMode {
-			this.EditSequenceColorsMode = false
+		if this.EditSequenceColorPickerMode {
+			this.EditSequenceColorPickerMode = false
 			this.Functions[this.EditWhichSequence][common.Function5_Color].State = false
 		}
 
@@ -661,7 +661,7 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 		}
 
 		// Turn off the edit sequence colors button.
-		if this.EditSequenceColorsMode {
+		if this.EditSequenceColorPickerMode {
 			removeColorPicker(this, eventsForLaunchpad, guiButtons, commandChannels)
 			// If the Selected Color has come back as empty this means we didn't select any colors.
 			// So restore the colors that were already there.

--- a/pkg/buttons/handle.go
+++ b/pkg/buttons/handle.go
@@ -297,6 +297,15 @@ func displayMode(sequenceNumber int, mode int, this *CurrentState, sequences []*
 			common.HideSequence(this.ChaserSequenceNumber, commandChannels)
 		}
 
+		// Turn off any flashing static buttons.
+		if this.StaticFlashing[sequenceNumber] {
+			// Unselect all fixtures.
+			this.SelectAllStaticFixtures = false
+			// Stop the flash of the static buttons,
+			flashwStaticButtons(sequenceNumber, false, commandChannels)
+			this.StaticFlashing[sequenceNumber] = false
+		}
+
 		// Hide the sequence.
 		common.HideSequence(sequenceNumber, commandChannels)
 

--- a/pkg/buttons/handle.go
+++ b/pkg/buttons/handle.go
@@ -41,7 +41,7 @@ import (
 func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLaunchpad chan common.ALight,
 	commandChannels []chan common.Command, guiButtons chan common.ALight) {
 
-	debug := true
+	debug := false
 
 	if this.SelectMode[this.SelectedSequence] == CHASER_FUNCTION {
 		this.TargetSequence = this.ChaserSequenceNumber
@@ -385,6 +385,11 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 
 		// Clear the buttons.
 		common.ClearSelectedRowOfButtons(this.SelectedSequence, eventsForLaunchpad, guiButtons)
+
+		// If we're trying to display the function bar we don't want a shutter chaser in view.
+		if !this.ScannerChaser[this.SelectedSequence] {
+			common.HideSequence(this.ChaserSequenceNumber, commandChannels)
+		}
 
 		// Show the function buttons.
 		ShowFunctionButtons(this, eventsForLaunchpad, guiButtons)

--- a/pkg/buttons/handle.go
+++ b/pkg/buttons/handle.go
@@ -56,6 +56,12 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 		printHandleDebug(this)
 	}
 
+	// Hide any function keys.
+	if debug {
+		fmt.Printf("hideAllFunctionKeys\n")
+	}
+	hideAllFunctionKeys(this, sequences, eventsForLaunchpad, guiButtons, commandChannels)
+
 	// Select Chase Pattern.
 	if this.EditPatternMode {
 
@@ -344,12 +350,6 @@ func displayMode(mode int, this *CurrentState, sequences []*common.Sequence, eve
 		printMode(this)
 	}
 
-	// Hide any function keys.
-	if debug {
-		fmt.Printf("hideAllFunctionKeys\n")
-	}
-	hideAllFunctionKeys(this, sequences, eventsForLaunchpad, guiButtons, commandChannels)
-
 	// Tailor the top buttons to the sequence type.
 	if debug {
 		fmt.Printf("ShowTopButtons\n")
@@ -529,6 +529,7 @@ func showStatusBar(this *CurrentState, sequences []*common.Sequence, guiButtons 
 
 func hideAllFunctionKeys(this *CurrentState, sequences []*common.Sequence, eventsForLaunchPad chan common.ALight, guiButtons chan common.ALight, commandChannels []chan common.Command) {
 
+	savedSelectedSequence := this.SelectedSequence
 	for sequenceNumber := range sequences {
 		if this.SelectMode[sequenceNumber] == FUNCTION {
 			common.ClearSelectedRowOfButtons(sequenceNumber, eventsForLaunchPad, guiButtons)
@@ -552,6 +553,7 @@ func hideAllFunctionKeys(this *CurrentState, sequences []*common.Sequence, event
 			}
 		}
 	}
+	this.SelectedSequence = savedSelectedSequence
 }
 
 func printHandleDebug(this *CurrentState) {

--- a/pkg/buttons/handle.go
+++ b/pkg/buttons/handle.go
@@ -385,8 +385,8 @@ func displayMode(mode int, this *CurrentState, sequences []*common.Sequence, eve
 			fmt.Printf("displayMode: NORMAL\n")
 		}
 
-		// If we have a shutter chaser running hide it.
-		if this.ScannerChaser[this.SelectedSequence] && this.SelectedType == "scanner" {
+		// Make sure we hide any shutter chaser.
+		if this.SelectedType == "scanner" {
 			common.HideSequence(this.ChaserSequenceNumber, commandChannels)
 		}
 		// Reveal the selected sequence.

--- a/pkg/buttons/handle.go
+++ b/pkg/buttons/handle.go
@@ -142,8 +142,9 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 	// 1st Press Select Sequence - This the first time we have pressed the select button.
 	// Simply select the selected sequence.
 	// But remember we have pressed this select button once.
-	if this.SelectMode[this.DisplaySequence] == NORMAL && !this.SelectButtonPressed[this.DisplaySequence] || //&& !this.ScannerChaser[this.SelectedSequence] ||
-		this.DisplayChaserShortCut && this.SelectMode[this.SelectedSequence] == CHASER_DISPLAY && this.ScannerChaser[this.SelectedSequence] {
+	if this.SelectMode[this.DisplaySequence] == NORMAL && !this.SelectButtonPressed[this.DisplaySequence] || // Normal mode and first time pressed.
+		// OR we're in the CHASER_DISPLAY mode with the chaser on and the DisplayChaserShortCut has fired
+		this.SelectMode[this.SelectedSequence] == CHASER_DISPLAY && this.ScannerChaser[this.SelectedSequence] && this.DisplayChaserShortCut {
 
 		// OK this is complicated,, but if we have switched on the shutter chaser from the scanner sequence function key 7 "Scanner Shutter Chase"
 		// We would at arrive at Step 2 below, where we would have switched the mode to CHASER_DISPLAY and force the display to show the shutter chaser.
@@ -295,7 +296,9 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 		return
 	}
 
-	// 2nd Press in scanner mode go into Shutter Chaser Mode for this sequence.
+	// First option of the 2nd Press in scanner mode go into Shutter Chaser Mode for this sequence.
+	// We're in Normal mode, We've Pressed twice and the scanner chaser is on and we're a scanner sequence.
+	// Or the DisplayChaserShortCut has fired.
 	if (this.SelectMode[this.SelectedSequence] == NORMAL &&
 		this.ScannerChaser[this.SelectedSequence] &&
 		this.SelectedType == "scanner" &&
@@ -335,12 +338,16 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 		return
 	}
 
-	// 2nd Press in rgb mode same select button go into Function Mode for this sequence.
+	// Second option of the 2nd Press in rgb mode same select button go into Function Mode for this sequence.
+	// We're in Normal mode, We've Pressed twice. we're a rgb sequence.
+	// Or
+	// We're in Normal mode, We've Pressed twice. but the scanner chaser is off
+	// Or
+	// We're in Chaser Display mode. and scanner sequence.
 	if (this.SelectMode[this.SelectedSequence] == NORMAL && this.SelectedType == "rgb") ||
 		(this.SelectMode[this.SelectedSequence] == NORMAL && !this.ScannerChaser[this.SelectedSequence]) ||
 		(this.SelectMode[this.SelectedSequence] == CHASER_DISPLAY && this.SelectedType == "scanner") &&
-			//this.EditStaticColorsMode[this.TargetSequence] && // AND static color mode, the case when we leave static colors edit mode.
-			this.SelectButtonPressed[this.SelectedSequence] {
+			this.SelectButtonPressed[this.SelectedSequence] { // Pressed twice.
 
 		if debug {
 			fmt.Printf("%d: 2nd Press Function Bar Mode - Handle Step 2\n", this.SelectedSequence)
@@ -401,13 +408,14 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 	}
 
 	// 3rd Press Status Mode and not a scanner - we display the fixture status enable/invert/disable buttons.
+	// We're in Function mode, pressed twice. and we're in edit sequence color mode. and we're NOT a scanner.
 	if this.SelectMode[this.SelectedSequence] == FUNCTION &&
 		!this.SelectButtonPressed[this.SelectedSequence] &&
 		!this.EditSequenceColorsMode &&
 		this.SelectedType != "scanner" {
 
 		if debug {
-			fmt.Printf("%d: Handle Step 3 Status Mode, Not a Scanner, Function Bar off, status buttons on\n", this.SelectedSequence)
+			fmt.Printf("%d: Handle 3 - Status Buttons on\n", this.SelectedSequence)
 		}
 
 		// Turn on status mode
@@ -560,7 +568,7 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 
 		// Turn off the function mode flag.
 		this.SelectMode[this.SelectedSequence] = NORMAL
-		// Now forget we pressed twice and start again.
+		// Remember that we've preseed twice.
 		this.SelectButtonPressed[this.SelectedSequence] = true
 
 		return
@@ -601,6 +609,8 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 
 		// Show the Fixture Status Buttons.
 		showFixtureStatus(this.TargetSequence, sequences[this.SelectedSequence].Number, sequences[this.SelectedSequence].NumberFixtures, this, eventsForLaunchpad, guiButtons, commandChannels)
+
+		return
 	}
 
 	// Are we in function mode ?

--- a/pkg/buttons/handle.go
+++ b/pkg/buttons/handle.go
@@ -41,7 +41,7 @@ import (
 func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLaunchpad chan common.ALight,
 	commandChannels []chan common.Command, guiButtons chan common.ALight) {
 
-	debug := false
+	debug := true
 
 	if this.SelectMode[this.SelectedSequence] == CHASER_FUNCTION {
 		this.TargetSequence = this.ChaserSequenceNumber

--- a/pkg/buttons/handle.go
+++ b/pkg/buttons/handle.go
@@ -294,7 +294,7 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 		return
 	}
 
-	// 2nd Press but in scanner mode Shutter Chaser Mode for this sequence.
+	// 2nd Press in scanner mode go into Shutter Chaser Mode for this sequence.
 	if (this.SelectMode[this.SelectedSequence] == NORMAL &&
 		this.ScannerChaser[this.SelectedSequence] &&
 		this.SelectedType == "scanner" &&

--- a/pkg/buttons/handle.go
+++ b/pkg/buttons/handle.go
@@ -526,7 +526,7 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 			// Set the colors.
 			sequences[this.EditWhichSequence].CurrentColors = sequences[this.EditWhichSequence].SequenceColors
 			// Show the colors
-			ShowRGBColorPicker(this.MasterBrightness, *sequences[this.EditWhichSequence], this.DisplaySequence, eventsForLaunchpad, guiButtons)
+			ShowRGBColorPicker(this.MasterBrightness, *sequences[this.EditWhichSequence], this.DisplaySequence, eventsForLaunchpad, guiButtons, commandChannels)
 			// Light the sequence selector button.
 			SequenceSelect(eventsForLaunchpad, guiButtons, this)
 			return

--- a/pkg/buttons/handle.go
+++ b/pkg/buttons/handle.go
@@ -42,7 +42,7 @@ import (
 func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLaunchpad chan common.ALight,
 	commandChannels []chan common.Command, guiButtons chan common.ALight) {
 
-	debug := false
+	debug := true
 
 	if this.SelectMode[this.SelectedSequence] == CHASER_FUNCTION {
 		this.TargetSequence = this.ChaserSequenceNumber
@@ -150,22 +150,6 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 		// Remember which select button has been pressed.
 		this.SelectButtonPressed[this.SelectedSequence] = true
 
-		// Set all static fixures to all. So we can set a static color for all fixtures.
-		if !this.SelectAllStaticFixtures && this.EditStaticColorsMode[this.DisplaySequence] && !this.ShowStaticColorPicker && !this.Loading {
-			if debug {
-				fmt.Printf("%d: Select All\n", this.DisplaySequence)
-			}
-			this.SelectAllStaticFixtures = true
-			// Update all the fixtures so they will flash.
-			cmd := common.Command{
-				Action: common.UpdateFlashAllStaticColorButtons,
-				Args: []common.Arg{
-					{Name: "StaticFlash", Value: this.SelectAllStaticFixtures},
-				},
-			}
-			common.SendCommandToSequence(this.TargetSequence, cmd, commandChannels)
-		}
-
 		// Now display the selected mode.
 		displayMode(this.SelectMode[this.SelectedSequence], this, sequences, eventsForLaunchpad, guiButtons, commandChannels)
 
@@ -184,19 +168,6 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 
 		if debug {
 			fmt.Printf("%d: 2nd Press Function Bar Mode - Handle Step 2\n", this.SelectedSequence)
-		}
-
-		// Toggle the select all static fixuure off.
-		if this.SelectAllStaticFixtures {
-			this.SelectAllStaticFixtures = false
-			// Update all the fixtures so they will stop flashing.
-			cmd := common.Command{
-				Action: common.UpdateFlashAllStaticColorButtons,
-				Args: []common.Arg{
-					{Name: "StaticFlash", Value: this.SelectAllStaticFixtures},
-				},
-			}
-			common.SendCommandToSequence(this.TargetSequence, cmd, commandChannels)
 		}
 
 		// Calculate the next mode.
@@ -408,7 +379,8 @@ func displayMode(mode int, this *CurrentState, sequences []*common.Sequence, eve
 		if this.SelectedType == "scanner" {
 			common.HideSequence(this.ChaserSequenceNumber, commandChannels)
 		}
-		// Reveal the selected sequence.
+		// Force the reveal the selected sequence.
+		common.HideSequence(this.SelectedSequence, commandChannels)
 		common.RevealSequence(this.SelectedSequence, commandChannels)
 
 		return

--- a/pkg/buttons/handle.go
+++ b/pkg/buttons/handle.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/dhowlett99/dmxlights/pkg/common"
-	"github.com/dhowlett99/dmxlights/pkg/sequence"
 )
 
 //		+-------------------+
@@ -115,9 +114,6 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 
 	// Light the top buttons.
 	common.ShowTopButtons(sequences[this.DisplaySequence].Type, eventsForLaunchpad, guiButtons)
-
-	// Light the sequence selector button.
-	sequence.SequenceSelect(eventsForLaunchpad, guiButtons, this.DisplaySequence)
 
 	// Light the strobe button.
 	common.ShowStrobeButtonStatus(this.Strobe[this.DisplaySequence], eventsForLaunchpad, guiButtons)
@@ -273,17 +269,14 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 		if this.ScannerChaser[this.SelectedSequence] && this.SelectedType == "scanner" {
 			if this.SelectMode[this.SelectedSequence] == NORMAL {
 				common.HideSequence(this.ChaserSequenceNumber, commandChannels)
-				this.SelectMode[this.SelectedSequence] = CHASER_DISPLAY
 				common.RevealSequence(this.SelectedSequence, commandChannels)
-			} else {
-				this.SelectMode[this.SelectedSequence] = NORMAL
-				common.HideSequence(this.ChaserSequenceNumber, commandChannels)
 			}
 		}
 		if debug {
 			printMode(this)
 		}
-
+		// Light the sequence selector button.
+		SequenceSelect(eventsForLaunchpad, guiButtons, this)
 		return
 	}
 
@@ -330,6 +323,8 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 			printMode(this)
 		}
 
+		// Light the sequence selector button.
+		SequenceSelect(eventsForLaunchpad, guiButtons, this)
 		return
 	}
 
@@ -402,6 +397,8 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 			printMode(this)
 		}
 
+		// Light the sequence selector button.
+		SequenceSelect(eventsForLaunchpad, guiButtons, this)
 		return
 	}
 
@@ -434,6 +431,8 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 			printMode(this)
 		}
 
+		// Light the sequence selector button.
+		SequenceSelect(eventsForLaunchpad, guiButtons, this)
 		return
 	}
 
@@ -484,6 +483,8 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 			printMode(this)
 		}
 
+		// Light the sequence selector button.
+		SequenceSelect(eventsForLaunchpad, guiButtons, this)
 		return
 	}
 
@@ -510,6 +511,8 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 			this.EditPatternMode = true
 			common.HideSequence(this.SelectedSequence, commandChannels)
 			ShowPatternSelectionButtons(this, sequences[this.SelectedSequence].Master, *sequences[this.SelectedSequence], this.DisplaySequence, eventsForLaunchpad, guiButtons)
+			// Light the sequence selector button.
+			SequenceSelect(eventsForLaunchpad, guiButtons, this)
 			return
 		}
 
@@ -524,6 +527,8 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 			sequences[this.EditWhichSequence].CurrentColors = sequences[this.EditWhichSequence].SequenceColors
 			// Show the colors
 			ShowRGBColorPicker(this.MasterBrightness, *sequences[this.EditWhichSequence], this.DisplaySequence, eventsForLaunchpad, guiButtons)
+			// Light the sequence selector button.
+			SequenceSelect(eventsForLaunchpad, guiButtons, this)
 			return
 		}
 
@@ -542,6 +547,8 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 			}
 		}
 		if static {
+			// Light the sequence selector button.
+			SequenceSelect(eventsForLaunchpad, guiButtons, this)
 			return
 		}
 
@@ -580,7 +587,8 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 		if debug {
 			printMode(this)
 		}
-
+		// Light the sequence selector button.
+		SequenceSelect(eventsForLaunchpad, guiButtons, this)
 		return
 	}
 
@@ -623,7 +631,8 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 		if debug {
 			printMode(this)
 		}
-
+		// Light the sequence selector button.
+		SequenceSelect(eventsForLaunchpad, guiButtons, this)
 		return
 	}
 
@@ -684,7 +693,8 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 		if debug {
 			printMode(this)
 		}
-
+		// Light the sequence selector button.
+		SequenceSelect(eventsForLaunchpad, guiButtons, this)
 		return
 	}
 

--- a/pkg/buttons/handle.go
+++ b/pkg/buttons/handle.go
@@ -40,7 +40,7 @@ import (
 func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLaunchpad chan common.ALight,
 	commandChannels []chan common.Command, guiButtons chan common.ALight) {
 
-	debug := true
+	debug := false
 
 	if this.SelectMode[this.SelectedSequence] == CHASER_FUNCTION {
 		this.TargetSequence = this.ChaserSequenceNumber
@@ -276,7 +276,10 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 		// Show this sequence running status in the start/stop button.
 		common.ShowRunningStatus(this.SelectedSequence, this.Running, eventsForLaunchpad, guiButtons)
 
-		common.ClearSelectedRowOfButtons(this.SelectedSequence, eventsForLaunchpad, guiButtons)
+		// Clear the select unless we're in static mode for this sequence.
+		if !this.EditStaticColorsMode[this.SelectedSequence] {
+			common.ClearSelectedRowOfButtons(this.SelectedSequence, eventsForLaunchpad, guiButtons)
+		}
 
 		// Now select the correct exit mode based on if we're a scanner or not.
 		if this.SelectMode[this.SelectedSequence] == NORMAL && this.ScannerChaser[this.SelectedSequence] && this.SelectedType == "scanner" {

--- a/pkg/buttons/handle.go
+++ b/pkg/buttons/handle.go
@@ -221,8 +221,6 @@ func displayMode(sequenceNumber int, mode int, this *CurrentState, sequences []*
 			fmt.Printf("displayMode: NORMAL STATIC\n")
 		}
 
-		this.EditStaticColorsMode[sequenceNumber] = true
-
 		// Make sure we hide any shutter chaser.
 		if this.SelectedType == "scanner" {
 			common.HideSequence(this.ChaserSequenceNumber, commandChannels)
@@ -267,8 +265,6 @@ func displayMode(sequenceNumber int, mode int, this *CurrentState, sequences []*
 		if debug {
 			fmt.Printf("displayMode: CHASER_DISPLAY\n")
 		}
-
-		this.EditStaticColorsMode[sequenceNumber] = true
 
 		// Hide the selected sequence.
 		common.HideSequence(sequenceNumber, commandChannels)

--- a/pkg/buttons/handle.go
+++ b/pkg/buttons/handle.go
@@ -280,14 +280,14 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 		return
 	}
 
-	// 2nd Press but in scanner mode same select button go into Function Mode for this sequence.
+	// 2nd Press but in scanner mode Shutter Chaser Mode for this sequence.
 	if (this.SelectMode[this.SelectedSequence] == NORMAL &&
 		this.ScannerChaser &&
 		this.SelectedType == "scanner" &&
 		this.SelectButtonPressed[this.SelectedSequence]) || this.DisplayChaserShortCut {
 
 		if debug {
-			fmt.Printf("%d: We are a SCANNER - 2nd Press Function Bar Mode - Handle Step 2\n", this.SelectedSequence)
+			fmt.Printf("%d: We are a SCANNER - 2nd Press Shutter Chase Mode - Handle Step 2\n", this.SelectedSequence)
 		}
 
 		// Set function mode. And take note if we arrived using the shortcut.
@@ -299,6 +299,14 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 			this.SelectButtonPressed[this.SelectedSequence] = false
 		}
 
+		// Update the bottom buttons.
+		common.UpdateBottomButtons("rgb", guiButtons)
+		common.UpdateStatusBar(fmt.Sprintf("Speed %02d", this.Speed[this.ChaserSequenceNumber]), "speed", false, guiButtons)
+		common.UpdateStatusBar(fmt.Sprintf("Shift %02d", this.RGBShift[this.ChaserSequenceNumber]), "shift", false, guiButtons)
+		common.UpdateStatusBar(fmt.Sprintf("Size %02d", this.RGBSize[this.ChaserSequenceNumber]), "size", false, guiButtons)
+		common.UpdateStatusBar(fmt.Sprintf("Fade %02d", this.RGBFade[this.ChaserSequenceNumber]), "fade", false, guiButtons)
+
+		// Set the Shutter Chaser mode.
 		this.SelectMode[this.SelectedSequence] = CHASER_DISPLAY
 
 		// Hide the rotating sequence.
@@ -552,27 +560,11 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 		// Turn on status mode
 		this.SelectMode[this.SelectedSequence] = STATUS
 
-		// Update the buttons: speed
-		common.LabelButton(0, 7, "Speed\nDown", guiButtons)
-		common.LabelButton(1, 7, "Speed\nUp", guiButtons)
 		// Update the status bar
 		common.UpdateStatusBar(fmt.Sprintf("Speed %02d", this.Speed[this.TargetSequence]), "speed", false, guiButtons)
 
-		common.LabelButton(2, 7, "Shift\nDown", guiButtons)
-		common.LabelButton(3, 7, "Shift\nUp", guiButtons)
-
-		common.LabelButton(4, 7, "Size\nDown", guiButtons)
-		common.LabelButton(5, 7, "Size\nUp", guiButtons)
-
-		if this.SelectedType == "rgb" {
-			common.LabelButton(6, 7, "Fade\nSoft", guiButtons)
-			common.LabelButton(7, 7, "Fade\nSharp", guiButtons)
-		}
-
-		if this.SelectedType == "scanner" {
-			common.LabelButton(6, 7, "Coord\nDown", guiButtons)
-			common.LabelButton(7, 7, "Coord\nUp", guiButtons)
-		}
+		// Update the buttons: speed
+		common.UpdateBottomButtons(this.SelectedType, guiButtons)
 
 		// If the chase is running, hide it.
 		if this.ScannerChaser && this.SelectedType == "scanner" {

--- a/pkg/buttons/handle.go
+++ b/pkg/buttons/handle.go
@@ -42,7 +42,7 @@ import (
 func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLaunchpad chan common.ALight,
 	commandChannels []chan common.Command, guiButtons chan common.ALight) {
 
-	debug := true
+	debug := false
 
 	if this.SelectMode[this.SelectedSequence] == CHASER_FUNCTION {
 		this.TargetSequence = this.ChaserSequenceNumber
@@ -104,6 +104,14 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 			}
 			common.SendCommandToSequence(this.SelectedSequence, cmd, commandChannels)
 		}
+	}
+
+	// We're in Scanner Gobo Selection Mode.
+	if this.Functions[this.SelectedSequence][common.Function6_Static_Gobo].State &&
+		!this.EditStaticColorsMode[this.EditWhichStaticSequence] &&
+		sequences[this.SelectedSequence].Type == "scanner" {
+		this.Functions[this.SelectedSequence][common.Function6_Static_Gobo].State = false
+		this.EditGoboSelectionMode = false
 	}
 
 	// 1st Press Select Sequence - This the first time we have pressed the select button.
@@ -327,7 +335,7 @@ func removeColorPicker(this *CurrentState, eventsForLaunchpad chan common.ALight
 
 func displayMode(mode int, this *CurrentState, sequences []*common.Sequence, eventsForLaunchpad chan common.ALight, guiButtons chan common.ALight, commandChannels []chan common.Command) {
 
-	debug := true
+	debug := false
 
 	// Clear the buttons.
 	common.ClearSelectedRowOfButtons(this.SelectedSequence, eventsForLaunchpad, guiButtons)

--- a/pkg/buttons/handle.go
+++ b/pkg/buttons/handle.go
@@ -42,7 +42,7 @@ import (
 func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLaunchpad chan common.ALight,
 	commandChannels []chan common.Command, guiButtons chan common.ALight) {
 
-	debug := true
+	debug := false
 
 	if this.SelectMode[this.SelectedSequence] == CHASER_DISPLAY ||
 		this.SelectMode[this.SelectedSequence] == CHASER_FUNCTION {
@@ -173,7 +173,7 @@ func removeColorPicker(this *CurrentState, eventsForLaunchpad chan common.ALight
 
 func displayMode(mode int, this *CurrentState, sequences []*common.Sequence, eventsForLaunchpad chan common.ALight, guiButtons chan common.ALight, commandChannels []chan common.Command) {
 
-	debug := true
+	debug := false
 
 	// Clear the buttons.
 	common.ClearSelectedRowOfButtons(this.SelectedSequence, eventsForLaunchpad, guiButtons)
@@ -216,7 +216,7 @@ func displayMode(mode int, this *CurrentState, sequences []*common.Sequence, eve
 		if this.StaticFlashing {
 
 			if debug {
-				fmt.Printf("flashwStaticButtons: false\n")
+				fmt.Printf("flashwStaticButtons: %t\n", this.StaticFlashing)
 			}
 
 			// Unselect all fixtures.
@@ -224,7 +224,6 @@ func displayMode(mode int, this *CurrentState, sequences []*common.Sequence, eve
 
 			// Stop the flash of the static buttons,
 			flashwStaticButtons(this.SelectedSequence, false, commandChannels)
-
 			this.StaticFlashing = false
 		}
 
@@ -281,6 +280,7 @@ func displayMode(mode int, this *CurrentState, sequences []*common.Sequence, eve
 
 			// Stop the flash of the static buttons,
 			flashwStaticButtons(this.ChaserSequenceNumber, false, commandChannels)
+			this.StaticFlashing = false
 		}
 
 		return
@@ -360,6 +360,19 @@ func displayMode(mode int, this *CurrentState, sequences []*common.Sequence, eve
 		}
 		// Hide the normal sequence.
 		common.HideSequence(this.SelectedSequence, commandChannels)
+
+		if this.StaticFlashing {
+			// Unselect all fixtures.
+			this.SelectAllStaticFixtures = false
+
+			if debug {
+				fmt.Printf("flashwStaticButtons: false\n")
+			}
+
+			// Stop the flash of the static buttons,
+			flashwStaticButtons(this.ChaserSequenceNumber, false, commandChannels)
+			this.StaticFlashing = false
+		}
 
 		// Display the fixture status bar.
 		showFixtureStatus(this.TargetSequence, sequences[this.SelectedSequence].Number, sequences[this.SelectedSequence].NumberFixtures, this, eventsForLaunchpad, guiButtons, commandChannels)

--- a/pkg/buttons/handle.go
+++ b/pkg/buttons/handle.go
@@ -469,55 +469,97 @@ func displayMode(mode int, this *CurrentState, sequences []*common.Sequence, eve
 
 func showStatusBar(this *CurrentState, sequences []*common.Sequence, guiButtons chan common.ALight) {
 
-	// Update the status bar
-	common.UpdateStatusBar(fmt.Sprintf("Speed %02d", this.Speed[this.TargetSequence]), "speed", false, guiButtons)
-
-	// Update the buttons: speed
-	common.UpdateBottomButtons(this.SelectedType, guiButtons)
-
-	if this.Strobe[this.SelectedSequence] {
-		common.UpdateStatusBar(fmt.Sprintf("Strobe %02d", this.StrobeSpeed[this.DisplaySequence]), "speed", false, guiButtons)
-	} else {
-		if this.Functions[this.SelectedSequence][common.Function8_Music_Trigger].State {
-			common.UpdateStatusBar("  MUSIC  ", "speed", false, guiButtons)
-		} else {
-			common.UpdateStatusBar(fmt.Sprintf("Speed %02d", this.Speed[this.DisplaySequence]), "speed", false, guiButtons)
-		}
-	}
-
 	sensitivity := common.FindSensitivity(this.SoundGain)
 	common.UpdateStatusBar(fmt.Sprintf("Sensitivity %02d", sensitivity), "sensitivity", false, guiButtons)
 	common.UpdateStatusBar(fmt.Sprintf("Master %02d", this.MasterBrightness), "master", false, guiButtons)
 
-	if sequences[this.TargetSequence].Type == "rgb" && sequences[this.TargetSequence].Label != "chaser" {
+	common.UpdateBottomButtons(this.SelectedType, guiButtons)
+
+	// Speed
+
+	// RGB
+	if sequences[this.TargetSequence].Type == "rgb" {
+		if this.Strobe[this.SelectedSequence] {
+			common.UpdateStatusBar(fmt.Sprintf("Strobe %02d", this.StrobeSpeed[this.DisplaySequence]), "speed", false, guiButtons)
+		} else {
+			if this.Functions[this.SelectedSequence][common.Function8_Music_Trigger].State {
+				common.UpdateStatusBar("  MUSIC  ", "speed", false, guiButtons)
+			} else {
+				common.UpdateStatusBar(fmt.Sprintf("Speed %02d", this.Speed[this.DisplaySequence]), "speed", false, guiButtons)
+			}
+		}
 		common.UpdateStatusBar(fmt.Sprintf("Shift %02d", this.RGBShift[this.TargetSequence]), "shift", false, guiButtons)
 		common.UpdateStatusBar(fmt.Sprintf("Size %02d", this.RGBSize[this.TargetSequence]), "size", false, guiButtons)
 		common.UpdateStatusBar(fmt.Sprintf("Fade %02d", this.RGBFade[this.TargetSequence]), "fade", false, guiButtons)
 		common.UpdateStatusBar("       ", "tilt", false, guiButtons)
-
 		common.UpdateStatusBar(fmt.Sprintf("Red %02d", this.StaticButtons[this.TargetSequence].Color.R), "red", false, guiButtons)
 		common.UpdateStatusBar(fmt.Sprintf("Green %02d", this.StaticButtons[this.TargetSequence].Color.G), "green", false, guiButtons)
 		common.UpdateStatusBar(fmt.Sprintf("Blue %02d", this.StaticButtons[this.TargetSequence].Color.B), "blue", false, guiButtons)
+		common.UpdateStatusBar(fmt.Sprintf("Speed %02d", this.Speed[this.ChaserSequenceNumber]), "speed", false, guiButtons)
+
+		common.LabelButton(0, 7, "Speed\nDown", guiButtons)
+		common.LabelButton(1, 7, "Speed\nUp", guiButtons)
+		common.LabelButton(2, 7, "Shift\nDown", guiButtons)
+		common.LabelButton(3, 7, "Shift\nUp", guiButtons)
+		common.LabelButton(4, 7, "Size\nDown", guiButtons)
+		common.LabelButton(5, 7, "Size\nUp", guiButtons)
+		common.LabelButton(6, 7, "Fade\nSoft", guiButtons)
+		common.LabelButton(7, 7, "Fade\nSharp", guiButtons)
 	}
 
-	if sequences[this.TargetSequence].Type == "rgb" && sequences[this.TargetSequence].Label == "chaser" {
-		common.LabelButton(0, 7, "Chase\nSpeed\nDown", guiButtons)
-		common.LabelButton(1, 7, "Chase\nSpeed\nUp", guiButtons)
-		common.UpdateStatusBar(fmt.Sprintf("Chase Speed %02d", this.Speed[this.ChaserSequenceNumber]), "speed", false, guiButtons)
-		common.LabelButton(2, 7, "Chase\nShift\nDown", guiButtons)
-		common.LabelButton(3, 7, "Chase\nShift\nUp", guiButtons)
-		common.LabelButton(4, 7, "Chase\nSize\nDown", guiButtons)
-		common.LabelButton(5, 7, "Chase\nSize\nUp", guiButtons)
-		common.LabelButton(6, 7, "Chase\nFade\nSoft", guiButtons)
-		common.LabelButton(7, 7, "Chase\nFade\nSharp", guiButtons)
-	}
-
+	// SCANNER ROTATE
 	if sequences[this.SelectedSequence].Type == "scanner" {
-		label := getScannerShiftLabel(this.ScannerShift[this.TargetSequence])
-		common.UpdateStatusBar(fmt.Sprintf("Shift %s", label), "shift", false, guiButtons)
-		common.UpdateStatusBar(fmt.Sprintf("Size %02d", this.ScannerSize[this.TargetSequence]), "size", false, guiButtons)
-		label = getScannerCoordinatesLabel(this.ScannerCoordinates[this.TargetSequence])
-		common.UpdateStatusBar(fmt.Sprintf("Coord %s", label), "fade", false, guiButtons)
+		if this.Strobe[this.SelectedSequence] {
+			common.UpdateStatusBar(fmt.Sprintf("Strobe %02d", this.StrobeSpeed[this.DisplaySequence]), "speed", false, guiButtons)
+		} else {
+			if this.Functions[this.SelectedSequence][common.Function8_Music_Trigger].State {
+				common.UpdateStatusBar("  MUSIC  ", "speed", false, guiButtons)
+			} else {
+				common.UpdateStatusBar(fmt.Sprintf("Rotate Speed %02d", this.Speed[this.DisplaySequence]), "speed", false, guiButtons)
+			}
+		}
+		if this.SelectMode[this.TargetSequence] == NORMAL || this.SelectMode[this.TargetSequence] == FUNCTION || this.SelectMode[this.TargetSequence] == STATUS {
+			label := getScannerShiftLabel(this.ScannerShift[this.TargetSequence])
+			common.UpdateStatusBar(fmt.Sprintf("Rotate Shift %s", label), "shift", false, guiButtons)
+			common.UpdateStatusBar(fmt.Sprintf("Rotate Size %02d", this.ScannerSize[this.TargetSequence]), "size", false, guiButtons)
+			label = getScannerCoordinatesLabel(this.ScannerCoordinates[this.TargetSequence])
+			common.UpdateStatusBar(fmt.Sprintf("Rotate Coord %s", label), "fade", false, guiButtons)
+			common.UpdateStatusBar(fmt.Sprintf("Rotate Speed %02d", this.Speed[this.ChaserSequenceNumber]), "speed", false, guiButtons)
+
+			common.LabelButton(0, 7, "Rotate\nSpeed\nDown", guiButtons)
+			common.LabelButton(1, 7, "Rotate\nSpeed\nUp", guiButtons)
+			common.LabelButton(2, 7, "Rotate\nShift\nDown", guiButtons)
+			common.LabelButton(3, 7, "Rotate\nShift\nUp", guiButtons)
+			common.LabelButton(4, 7, "Rotate\nSize\nDown", guiButtons)
+			common.LabelButton(5, 7, "Rotate\nSize\nUp", guiButtons)
+			common.LabelButton(6, 7, "Rotate\nCooord\nDown", guiButtons)
+			common.LabelButton(7, 7, "Rotate\nCooord\nUp", guiButtons)
+
+		}
+
+		// SHUTTER CHASER
+		if this.SelectMode[this.TargetSequence] == CHASER_DISPLAY || this.SelectMode[this.TargetSequence] == CHASER_FUNCTION {
+			if this.Strobe[this.SelectedSequence] {
+				common.UpdateStatusBar(fmt.Sprintf("Strobe %02d", this.StrobeSpeed[this.TargetSequence]), "speed", false, guiButtons)
+			} else {
+				if this.Functions[this.SelectedSequence][common.Function8_Music_Trigger].State {
+					common.UpdateStatusBar("  MUSIC  ", "speed", false, guiButtons)
+				} else {
+					common.UpdateStatusBar(fmt.Sprintf("Chase Speed %02d", this.Speed[this.TargetSequence]), "speed", false, guiButtons)
+				}
+			}
+			common.UpdateStatusBar(fmt.Sprintf("Chase Shift %02d", this.RGBShift[this.TargetSequence]), "shift", false, guiButtons)
+			common.UpdateStatusBar(fmt.Sprintf("Chase Size %02d", this.RGBSize[this.TargetSequence]), "size", false, guiButtons)
+			common.UpdateStatusBar(fmt.Sprintf("Chase Fade %02d", this.RGBFade[this.TargetSequence]), "fade", false, guiButtons)
+			common.LabelButton(0, 7, "Chase\nSpeed\nDown", guiButtons)
+			common.LabelButton(1, 7, "Chase\nSpeed\nUp", guiButtons)
+			common.LabelButton(2, 7, "Chase\nShift\nDown", guiButtons)
+			common.LabelButton(3, 7, "Chase\nShift\nUp", guiButtons)
+			common.LabelButton(4, 7, "Chase\nSize\nDown", guiButtons)
+			common.LabelButton(5, 7, "Chase\nSize\nUp", guiButtons)
+			common.LabelButton(6, 7, "Chase\nFade\nSoft", guiButtons)
+			common.LabelButton(7, 7, "Chase\nFade\nSharp", guiButtons)
+		}
 
 		// Hide the color editing buttons.
 		common.UpdateStatusBar(fmt.Sprintf("Tilt %02d", this.OffsetTilt), "tilt", false, guiButtons)

--- a/pkg/buttons/handle.go
+++ b/pkg/buttons/handle.go
@@ -340,6 +340,7 @@ func displayMode(mode int, this *CurrentState, sequences []*common.Sequence, eve
 
 	switch {
 
+	default:
 	case mode == NORMAL:
 
 		if debug {
@@ -364,9 +365,7 @@ func displayMode(mode int, this *CurrentState, sequences []*common.Sequence, eve
 		common.HideSequence(this.SelectedSequence, commandChannels)
 
 		// Reveal the shutter chaser.
-		//if this.ScannerChaser[this.SelectedSequence] && this.SelectedType == "scanner" {
 		common.RevealSequence(this.ChaserSequenceNumber, commandChannels)
-		//}
 
 		return
 
@@ -376,18 +375,10 @@ func displayMode(mode int, this *CurrentState, sequences []*common.Sequence, eve
 			fmt.Printf("displayMode: FUNCTION  Seq:%d Shutter Chaser is %t\n", this.SelectedSequence, this.ScannerChaser[this.SelectedSequence])
 		}
 		// If we have a shutter chaser running hide it.
-		//if this.ScannerChaser[this.SelectedSequence] && this.SelectedType == "scanner" {
 		common.HideSequence(this.ChaserSequenceNumber, commandChannels)
-		//}
+
 		// Hide the sequence.
 		common.HideSequence(this.SelectedSequence, commandChannels)
-
-		// Update the bottom buttons.
-		common.UpdateBottomButtons("rgb", guiButtons)
-		common.UpdateStatusBar(fmt.Sprintf("Speed %02d", this.Speed[this.ChaserSequenceNumber]), "speed", false, guiButtons)
-		common.UpdateStatusBar(fmt.Sprintf("Shift %02d", this.RGBShift[this.ChaserSequenceNumber]), "shift", false, guiButtons)
-		common.UpdateStatusBar(fmt.Sprintf("Size %02d", this.RGBSize[this.ChaserSequenceNumber]), "size", false, guiButtons)
-		common.UpdateStatusBar(fmt.Sprintf("Fade %02d", this.RGBFade[this.ChaserSequenceNumber]), "fade", false, guiButtons)
 
 		// Show the function buttons.
 		ShowFunctionButtons(this, eventsForLaunchpad, guiButtons)
@@ -405,17 +396,6 @@ func displayMode(mode int, this *CurrentState, sequences []*common.Sequence, eve
 		}
 		// Hide the normal sequence.
 		common.HideSequence(this.SelectedSequence, commandChannels)
-
-		// Update the labels.
-		common.LabelButton(0, 7, "Chase\nSpeed\nDown", guiButtons)
-		common.LabelButton(1, 7, "Chase\nSpeed\nUp", guiButtons)
-		common.UpdateStatusBar(fmt.Sprintf("Chase Speed %02d", this.Speed[this.ChaserSequenceNumber]), "speed", false, guiButtons)
-		common.LabelButton(2, 7, "Chase\nShift\nDown", guiButtons)
-		common.LabelButton(3, 7, "Chase\nShift\nUp", guiButtons)
-		common.LabelButton(4, 7, "Chase\nSize\nDown", guiButtons)
-		common.LabelButton(5, 7, "Chase\nSize\nUp", guiButtons)
-		common.LabelButton(6, 7, "Chase\nFade\nSoft", guiButtons)
-		common.LabelButton(7, 7, "Chase\nFade\nSharp", guiButtons)
 
 		// Show the chaser function buttons.
 		this.TargetSequence = this.ChaserSequenceNumber
@@ -465,7 +445,7 @@ func showStatusBar(this *CurrentState, sequences []*common.Sequence, guiButtons 
 	common.UpdateStatusBar(fmt.Sprintf("Sensitivity %02d", sensitivity), "sensitivity", false, guiButtons)
 	common.UpdateStatusBar(fmt.Sprintf("Master %02d", this.MasterBrightness), "master", false, guiButtons)
 
-	if sequences[this.TargetSequence].Type == "rgb" {
+	if sequences[this.TargetSequence].Type == "rgb" && sequences[this.TargetSequence].Label != "chaser" {
 		common.UpdateStatusBar(fmt.Sprintf("Shift %02d", this.RGBShift[this.TargetSequence]), "shift", false, guiButtons)
 		common.UpdateStatusBar(fmt.Sprintf("Size %02d", this.RGBSize[this.TargetSequence]), "size", false, guiButtons)
 		common.UpdateStatusBar(fmt.Sprintf("Fade %02d", this.RGBFade[this.TargetSequence]), "fade", false, guiButtons)
@@ -475,6 +455,19 @@ func showStatusBar(this *CurrentState, sequences []*common.Sequence, guiButtons 
 		common.UpdateStatusBar(fmt.Sprintf("Green %02d", this.StaticButtons[this.TargetSequence].Color.G), "green", false, guiButtons)
 		common.UpdateStatusBar(fmt.Sprintf("Blue %02d", this.StaticButtons[this.TargetSequence].Color.B), "blue", false, guiButtons)
 	}
+
+	if sequences[this.TargetSequence].Type == "rgb" && sequences[this.TargetSequence].Label == "chaser" {
+		common.LabelButton(0, 7, "Chase\nSpeed\nDown", guiButtons)
+		common.LabelButton(1, 7, "Chase\nSpeed\nUp", guiButtons)
+		common.UpdateStatusBar(fmt.Sprintf("Chase Speed %02d", this.Speed[this.ChaserSequenceNumber]), "speed", false, guiButtons)
+		common.LabelButton(2, 7, "Chase\nShift\nDown", guiButtons)
+		common.LabelButton(3, 7, "Chase\nShift\nUp", guiButtons)
+		common.LabelButton(4, 7, "Chase\nSize\nDown", guiButtons)
+		common.LabelButton(5, 7, "Chase\nSize\nUp", guiButtons)
+		common.LabelButton(6, 7, "Chase\nFade\nSoft", guiButtons)
+		common.LabelButton(7, 7, "Chase\nFade\nSharp", guiButtons)
+	}
+
 	if sequences[this.SelectedSequence].Type == "scanner" {
 		label := getScannerShiftLabel(this.ScannerShift[this.TargetSequence])
 		common.UpdateStatusBar(fmt.Sprintf("Shift %s", label), "shift", false, guiButtons)

--- a/pkg/buttons/handle.go
+++ b/pkg/buttons/handle.go
@@ -213,20 +213,6 @@ func displayMode(mode int, this *CurrentState, sequences []*common.Sequence, eve
 		common.HideSequence(this.SelectedSequence, commandChannels)
 		common.RevealSequence(this.SelectedSequence, commandChannels)
 
-		if this.StaticFlashing {
-
-			if debug {
-				fmt.Printf("flashwStaticButtons: %t\n", this.StaticFlashing)
-			}
-
-			// Unselect all fixtures.
-			this.SelectAllStaticFixtures = false
-
-			// Stop the flash of the static buttons,
-			flashwStaticButtons(this.SelectedSequence, false, commandChannels)
-			this.StaticFlashing = false
-		}
-
 		return
 
 	case mode == NORMAL_STATIC:
@@ -254,7 +240,7 @@ func displayMode(mode int, this *CurrentState, sequences []*common.Sequence, eve
 
 		// Flash the static buttons,
 		flashwStaticButtons(this.SelectedSequence, true, commandChannels)
-		this.StaticFlashing = true
+		this.StaticFlashing[this.SelectedSequence] = true
 
 		return
 
@@ -270,7 +256,7 @@ func displayMode(mode int, this *CurrentState, sequences []*common.Sequence, eve
 		common.HideSequence(this.ChaserSequenceNumber, commandChannels)
 		common.RevealSequence(this.ChaserSequenceNumber, commandChannels)
 
-		if this.StaticFlashing {
+		if this.StaticFlashing[this.SelectedSequence] {
 			// Unselect all fixtures.
 			this.SelectAllStaticFixtures = false
 
@@ -280,7 +266,7 @@ func displayMode(mode int, this *CurrentState, sequences []*common.Sequence, eve
 
 			// Stop the flash of the static buttons,
 			flashwStaticButtons(this.ChaserSequenceNumber, false, commandChannels)
-			this.StaticFlashing = false
+			this.StaticFlashing[this.SelectedSequence] = false
 		}
 
 		return
@@ -309,7 +295,7 @@ func displayMode(mode int, this *CurrentState, sequences []*common.Sequence, eve
 
 		// Flash the static buttons,
 		flashwStaticButtons(this.ChaserSequenceNumber, true, commandChannels)
-		this.StaticFlashing = true
+		this.StaticFlashing[this.SelectedSequence] = true
 
 		return
 
@@ -355,13 +341,13 @@ func displayMode(mode int, this *CurrentState, sequences []*common.Sequence, eve
 			fmt.Printf("displayMode: STATUS\n")
 		}
 		// If we're a scanner sequence and trying to display the status bar we don't want a shutter chaser in view.
-		if this.ScannerChaser[this.SelectedSequence] && this.SelectedType == "scanner" {
+		if this.SelectedType == "scanner" {
 			common.HideSequence(this.ChaserSequenceNumber, commandChannels)
 		}
 		// Hide the normal sequence.
 		common.HideSequence(this.SelectedSequence, commandChannels)
 
-		if this.StaticFlashing {
+		if this.StaticFlashing[this.SelectedSequence] {
 			// Unselect all fixtures.
 			this.SelectAllStaticFixtures = false
 
@@ -371,7 +357,7 @@ func displayMode(mode int, this *CurrentState, sequences []*common.Sequence, eve
 
 			// Stop the flash of the static buttons,
 			flashwStaticButtons(this.ChaserSequenceNumber, false, commandChannels)
-			this.StaticFlashing = false
+			this.StaticFlashing[this.SelectedSequence] = false
 		}
 
 		// Display the fixture status bar.
@@ -581,7 +567,7 @@ func printHandleDebug(this *CurrentState) {
 	fmt.Printf("HANDLE: this.ScannerChaser[%d] running %t\n", this.DisplaySequence, this.ScannerChaser[this.DisplaySequence])
 	fmt.Printf("HANDLE: ================== WHAT SELECT MODE =================\n")
 	fmt.Printf("HANDLE: this.EditFixtureSelectionMode %t\n", this.EditFixtureSelectionMode)
-	fmt.Printf("HANDLE: this.StaticFlashing %t\n", this.StaticFlashing)
+	fmt.Printf("HANDLE: this.StaticFlashing %t\n", this.StaticFlashing[this.SelectedSequence])
 	fmt.Printf("HANDLE: this.EditWhichStaticSequence = %d\n", this.EditWhichStaticSequence)
 	fmt.Printf("HANDLE: this.SelectButtonPressed[%d] = %t\n", this.SelectedSequence, this.SelectButtonPressed[this.SelectedSequence])
 	fmt.Printf("HANDLE: this.SelectMode[%d] = %s\n", this.SelectedSequence, printMode(this.SelectMode[this.SelectedSequence]))

--- a/pkg/buttons/handle.go
+++ b/pkg/buttons/handle.go
@@ -42,7 +42,7 @@ import (
 func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLaunchpad chan common.ALight,
 	commandChannels []chan common.Command, guiButtons chan common.ALight) {
 
-	debug := true
+	debug := false
 
 	if this.SelectMode[this.SelectedSequence] == CHASER_FUNCTION {
 		this.TargetSequence = this.ChaserSequenceNumber

--- a/pkg/buttons/handle.go
+++ b/pkg/buttons/handle.go
@@ -40,7 +40,7 @@ import (
 func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLaunchpad chan common.ALight,
 	commandChannels []chan common.Command, guiButtons chan common.ALight) {
 
-	debug := true
+	debug := false
 
 	if this.SelectMode[this.SelectedSequence] == CHASER_FUNCTION {
 		this.TargetSequence = this.ChaserSequenceNumber

--- a/pkg/buttons/handle.go
+++ b/pkg/buttons/handle.go
@@ -86,7 +86,6 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 		this.ShowRGBColorPicker = false
 		this.Functions[this.EditWhichStaticSequence][common.Function5_Color].State = false
 		removeColorPicker(this, eventsForLaunchpad, guiButtons, commandChannels)
-		this.SelectMode[this.SelectedSequence] = NORMAL
 
 		// If the Selected Color has come back as empty this means we didn't select any colors.
 		// So restore the colors that were already there.
@@ -146,8 +145,6 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 
 func removeColorPicker(this *CurrentState, eventsForLaunchpad chan common.ALight, guiButtons chan common.ALight, commandChannels []chan common.Command) {
 
-	this.SelectButtonPressed[this.SelectedSequence] = false
-	this.SelectMode[this.SelectedSequence] = NORMAL
 	this.Functions[this.EditWhichStaticSequence][common.Function5_Color].State = false
 
 	// Clear the first three launchpad rows used by the color picker.
@@ -344,8 +341,12 @@ func displayMode(sequenceNumber int, mode int, this *CurrentState, sequences []*
 			// Unselect all fixtures.
 			this.SelectAllStaticFixtures = false
 
-			// Stop the flash of the static buttons,
-			flashwStaticButtons(sequenceNumber, false, commandChannels)
+			// Stop the flash of the static buttons, taking care to select the correct sequence.
+			if this.ScannerChaser[sequenceNumber] && this.SelectedType == "scanner" {
+				flashwStaticButtons(this.ChaserSequenceNumber, false, commandChannels)
+			} else {
+				flashwStaticButtons(sequenceNumber, false, commandChannels)
+			}
 			this.StaticFlashing[sequenceNumber] = false
 		}
 
@@ -503,7 +504,7 @@ func showStatusBar(this *CurrentState, sequences []*common.Sequence, guiButtons 
 func flashwStaticButtons(targetSequence int, state bool, commandChannels []chan common.Command) {
 
 	if debug {
-		fmt.Printf("flashwStaticButtons set to %t\n", state)
+		fmt.Printf("======> flashwStaticButtons: sequence %d set to %t\n", targetSequence, state)
 	}
 	// Add the flashing static buttons.
 	cmd := common.Command{

--- a/pkg/buttons/handle.go
+++ b/pkg/buttons/handle.go
@@ -130,6 +130,19 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 			fmt.Printf("%d: Show Sequence - Handle Step 1\n", this.SelectedSequence)
 		}
 
+		// Set all static fixures to all. So we can set a static color for all fixtures.
+		if this.EditStaticColorsMode[this.DisplaySequence] {
+			this.SelectAllStaticFixtures = true
+
+			cmd := common.Command{
+				Action: common.UpdateFlashAllStaticColorButtons,
+				Args: []common.Arg{
+					{Name: "Flash", Value: true},
+				},
+			}
+			common.SendCommandToSequence(this.SelectedSequence, cmd, commandChannels)
+		}
+
 		// Assume everything else is off.
 		this.SelectButtonPressed[0] = false
 		this.SelectButtonPressed[1] = false
@@ -168,6 +181,20 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 
 		if debug {
 			fmt.Printf("%d: 2nd Press Function Bar Mode - Handle Step 2\n", this.SelectedSequence)
+		}
+
+		// Turn off the all static colors flag.
+		if this.EditStaticColorsMode[this.DisplaySequence] && this.SelectAllStaticFixtures {
+			this.SelectAllStaticFixtures = false
+			this.SelectButtonPressed[this.DisplaySequence] = false
+
+			cmd := common.Command{
+				Action: common.UpdateFlashAllStaticColorButtons,
+				Args: []common.Arg{
+					{Name: "Flash", Value: false},
+				},
+			}
+			common.SendCommandToSequence(this.SelectedSequence, cmd, commandChannels)
 		}
 
 		// Calculate the next mode.

--- a/pkg/buttons/handle.go
+++ b/pkg/buttons/handle.go
@@ -56,11 +56,10 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 		printHandleDebug(this)
 	}
 
-	// Hide any function keys.
-	if debug {
-		fmt.Printf("hideAllFunctionKeys\n")
+	// Hide any function keys. As long as we're not in static mode.
+	if !this.EditStaticColorsMode[this.SelectedSequence] {
+		hideAllFunctionKeys(this, sequences, eventsForLaunchpad, guiButtons, commandChannels)
 	}
-	hideAllFunctionKeys(this, sequences, eventsForLaunchpad, guiButtons, commandChannels)
 
 	// Select Chase Pattern.
 	if this.EditPatternMode {
@@ -460,7 +459,7 @@ func displayMode(mode int, this *CurrentState, sequences []*common.Sequence, eve
 
 func showStatusBar(this *CurrentState, sequences []*common.Sequence, guiButtons chan common.ALight) {
 
-	debug := true
+	debug := false
 
 	if debug {
 		fmt.Printf("showStatusBar\n")
@@ -598,6 +597,10 @@ func showStatusBar(this *CurrentState, sequences []*common.Sequence, guiButtons 
 }
 
 func hideAllFunctionKeys(this *CurrentState, sequences []*common.Sequence, eventsForLaunchPad chan common.ALight, guiButtons chan common.ALight, commandChannels []chan common.Command) {
+
+	if debug {
+		fmt.Printf("hideAllFunctionKeys\n")
+	}
 
 	savedSelectedSequence := this.SelectedSequence
 	for sequenceNumber := range sequences {

--- a/pkg/buttons/handle.go
+++ b/pkg/buttons/handle.go
@@ -492,6 +492,7 @@ func hideAllFunctionKeys(this *CurrentState, sequences []*common.Sequence, event
 			if sequenceNumber != this.SelectedSequence {
 				// And turn off the function selected.
 				this.SelectMode[sequenceNumber] = NORMAL
+				this.SelectedSequence = sequenceNumber
 				displayMode(NORMAL, this, sequences, eventsForLaunchPad, guiButtons, commandChannels)
 			}
 		}

--- a/pkg/buttons/handle.go
+++ b/pkg/buttons/handle.go
@@ -141,8 +141,19 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 	// 1st Press Select Sequence - This the first time we have pressed the select button.
 	// Simply select the selected sequence.
 	// But remember we have pressed this select button once.
-	if this.SelectMode[this.DisplaySequence] == NORMAL &&
-		!this.SelectButtonPressed[this.DisplaySequence] {
+	if this.SelectMode[this.DisplaySequence] == NORMAL && !this.SelectButtonPressed[this.DisplaySequence] && !this.ScannerChaser ||
+		this.DisplayChaserShortCut && this.SelectMode[this.SelectedSequence] == CHASER_DISPLAY && this.ScannerChaser {
+
+		// OK this is complicated,, but if we have switched on the shutter chaser from the scanner sequence function key 7 "Scanner Shutter Chase"
+		// We would at arrive at Step 2 below, where we would have switched the mode to CHASER_DISPLAY and force the display to show the shutter chaser.
+		// What we are doing here is using the DisplayChaserShortCut flag to detect that this has happened and force the next step in the select press sequence to
+		// go back to the NORMAL mode and resume the sequence of select presses to as described in the header of this Handle() function.
+		if this.DisplayChaserShortCut {
+			this.SelectMode[this.DisplaySequence] = NORMAL
+			// And now forget this ever happened. Well untill the next shortcut is called.
+			this.DisplayChaserShortCut = false
+		}
+
 		if debug {
 			fmt.Printf("%d: Show Sequence - Handle Step 1\n", this.SelectedSequence)
 		}
@@ -295,7 +306,6 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 			if debug {
 				fmt.Printf("%d: Chaser Display entered via DisplayChaserShortCut\n", this.SelectedSequence)
 			}
-			this.DisplayChaserShortCut = false
 			this.SelectButtonPressed[this.SelectedSequence] = false
 		}
 
@@ -638,14 +648,6 @@ func HandleSelect(sequences []*common.Sequence, this *CurrentState, eventsForLau
 		// Now forget we pressed twice and start again.
 		this.SelectButtonPressed[this.SelectedSequence] = false
 
-		return
-	}
-
-	if this.SelectMode[this.SelectedSequence] == CHASER_DISPLAY && this.ScannerChaser {
-		if debug {
-			fmt.Printf("HANDLE %d: Handle 8 - Back to NORMAL mode from Shutter Chaser.\n", this.SelectedSequence)
-		}
-		this.SelectMode[this.SelectedSequence] = NORMAL
 		return
 	}
 

--- a/pkg/buttons/handle.go
+++ b/pkg/buttons/handle.go
@@ -291,8 +291,9 @@ func displayMode(sequenceNumber int, mode int, this *CurrentState, sequences []*
 		if debug {
 			fmt.Printf("displayMode: FUNCTION  Seq:%d Shutter Chaser is %t\n", sequenceNumber, this.ScannerChaser[sequenceNumber])
 		}
-		// If we have a shutter chaser running hide it.
-		if this.SelectedType == "scanner" {
+		// If we have a shutter chaser running force hide it.
+		if this.SequenceType[sequenceNumber] == "scanner" {
+			common.RevealSequence(this.ChaserSequenceNumber, commandChannels)
 			common.HideSequence(this.ChaserSequenceNumber, commandChannels)
 		}
 

--- a/pkg/buttons/load.go
+++ b/pkg/buttons/load.go
@@ -108,7 +108,7 @@ func loadConfig(sequences []*common.Sequence, this *CurrentState,
 			this.Functions[sequenceNumber][common.Function4_Bounce].State = sequences[sequenceNumber].Bounce
 			this.Functions[sequenceNumber][common.Function7_Invert_Chase].State = sequences[sequenceNumber].ScannerChaser
 			this.Functions[sequenceNumber][common.Function8_Music_Trigger].State = sequences[sequenceNumber].MusicTrigger
-			this.ScannerChaser = sequences[sequenceNumber].ScannerChaser
+			this.ScannerChaser[this.SelectedSequence] = sequences[sequenceNumber].ScannerChaser
 		}
 
 		// If we are loading a switch sequence, update our local copy of the switch settings.

--- a/pkg/buttons/load.go
+++ b/pkg/buttons/load.go
@@ -108,8 +108,12 @@ func loadConfig(sequences []*common.Sequence, this *CurrentState,
 			this.Functions[sequenceNumber][common.Function4_Bounce].State = sequences[sequenceNumber].Bounce
 			this.Functions[sequenceNumber][common.Function7_Invert_Chase].State = sequences[sequenceNumber].ScannerChaser
 			this.Functions[sequenceNumber][common.Function8_Music_Trigger].State = sequences[sequenceNumber].MusicTrigger
-			this.ScannerChaser[this.SelectedSequence] = sequences[sequenceNumber].ScannerChaser
+
 		}
+
+		this.SelectMode[this.SelectedSequence] = NORMAL
+		this.ScannerChaser[this.SelectedSequence] = sequences[sequenceNumber].ScannerChaser
+		this.EditStaticColorsMode[this.SelectedSequence] = false
 
 		// If we are loading a switch sequence, update our local copy of the switch settings.
 		if sequences[sequenceNumber].Type == "switch" {

--- a/pkg/buttons/load.go
+++ b/pkg/buttons/load.go
@@ -149,4 +149,18 @@ func loadConfig(sequences []*common.Sequence, this *CurrentState,
 	} else {
 		common.ShowStrobeButtonStatus(false, eventsForLaunchpad, guiButtons)
 	}
+
+	// Stop any static flashing.
+	if sequences[this.SelectedSequence].Static {
+		this.SelectAllStaticFixtures = true
+
+		cmd := common.Command{
+			Action: common.UpdateFlashAllStaticColorButtons,
+			Args: []common.Arg{
+				{Name: "Flash", Value: false},
+			},
+		}
+		common.SendCommandToSequence(this.SelectedSequence, cmd, commandChannels)
+
+	}
 }

--- a/pkg/buttons/load.go
+++ b/pkg/buttons/load.go
@@ -39,9 +39,6 @@ func loadConfig(sequences []*common.Sequence, this *CurrentState,
 	}
 	common.SendCommandToAllSequence(cmd, commandChannels)
 
-	// Used by SelectAllStaticFixtures so that we don't flash static button while loading.
-	this.Loading = true
-
 	AllFixturesOff(sequences, eventsForLaunchpad, guiButtons, dmxController, fixturesConfig, dmxInterfacePresent)
 
 	// Load the config.
@@ -152,4 +149,18 @@ func loadConfig(sequences []*common.Sequence, this *CurrentState,
 	} else {
 		common.ShowStrobeButtonStatus(false, eventsForLaunchpad, guiButtons)
 	}
+
+	// Clear any flashing
+	// Set a static color for an individual fixture.
+	cmd = common.Command{
+		Action: common.UpdateStaticColor,
+		Args: []common.Arg{
+			{Name: "Static", Value: true},
+			{Name: "FixtureNumber", Value: this.SelectedStaticFixtureNumber},
+			{Name: "StaticLampFlash", Value: false},
+			{Name: "SelectedColor", Value: sequences[this.TargetSequence].StaticColors[this.SelectedStaticFixtureNumber].SelectedColor},
+			{Name: "StaticColor", Value: sequences[this.TargetSequence].StaticColors[this.SelectedStaticFixtureNumber].Color},
+		},
+	}
+	common.SendCommandToSequence(this.TargetSequence, cmd, commandChannels)
 }

--- a/pkg/buttons/load.go
+++ b/pkg/buttons/load.go
@@ -39,6 +39,9 @@ func loadConfig(sequences []*common.Sequence, this *CurrentState,
 	}
 	common.SendCommandToAllSequence(cmd, commandChannels)
 
+	// Used by SelectAllStaticFixtures so that we don't flash static button while loading.
+	this.Loading = true
+
 	AllFixturesOff(sequences, eventsForLaunchpad, guiButtons, dmxController, fixturesConfig, dmxInterfacePresent)
 
 	// Load the config.
@@ -148,19 +151,5 @@ func loadConfig(sequences []*common.Sequence, this *CurrentState,
 		common.ShowStrobeButtonStatus(true, eventsForLaunchpad, guiButtons)
 	} else {
 		common.ShowStrobeButtonStatus(false, eventsForLaunchpad, guiButtons)
-	}
-
-	// Stop any static flashing.
-	if sequences[this.SelectedSequence].Static {
-		this.SelectAllStaticFixtures = true
-
-		cmd := common.Command{
-			Action: common.UpdateFlashAllStaticColorButtons,
-			Args: []common.Arg{
-				{Name: "Flash", Value: false},
-			},
-		}
-		common.SendCommandToSequence(this.SelectedSequence, cmd, commandChannels)
-
 	}
 }

--- a/pkg/buttons/menu.go
+++ b/pkg/buttons/menu.go
@@ -1,51 +1,78 @@
 package buttons
 
-// Create a sequence of menu items based on if chaser is running.
-func newMenu(chaser bool) []int {
-
-	if !chaser {
-		return []int{NORMAL, FUNCTION, STATUS}
-	} else {
-		return []int{NORMAL, FUNCTION, CHASER_DISPLAY, CHASER_FUNCTION, STATUS}
-	}
-
-}
-
 // getNextMenuItem get the next items in the menu sequence.
 // Wraps if your at the end.
-func getNextMenuItem(selectedMode int, chaser bool) int {
+func getNextMenuItem(currentMode int, chaser bool, editStaticColorMode bool) int {
 
-	menuOrder := newMenu(chaser)
+	menuOrder := []int{NORMAL, NORMAL_STATIC, FUNCTION, CHASER_DISPLAY, CHASER_DISPLAY_STATIC, CHASER_FUNCTION, STATUS}
 
-	if !chaser {
+	if !chaser && !editStaticColorMode {
 		switch {
-		case selectedMode == NORMAL:
-			return menuOrder[1]
+		case currentMode == NORMAL:
+			return menuOrder[FUNCTION]
 
-		case selectedMode == FUNCTION:
-			return menuOrder[2]
+		case currentMode == FUNCTION:
+			return menuOrder[STATUS]
 
-		case selectedMode == STATUS:
-			return menuOrder[0]
+		case currentMode == STATUS:
+			return menuOrder[NORMAL]
 		}
 	}
 
-	if chaser {
+	if !chaser && editStaticColorMode {
 		switch {
-		case selectedMode == NORMAL:
-			return menuOrder[1]
+		case currentMode == NORMAL:
+			return menuOrder[NORMAL_STATIC]
 
-		case selectedMode == FUNCTION:
-			return menuOrder[2]
+		case currentMode == NORMAL_STATIC:
+			return menuOrder[FUNCTION]
 
-		case selectedMode == CHASER_DISPLAY:
-			return menuOrder[3]
+		case currentMode == FUNCTION:
+			return menuOrder[STATUS]
 
-		case selectedMode == CHASER_FUNCTION:
-			return menuOrder[4]
+		case currentMode == STATUS:
+			return menuOrder[NORMAL]
+		}
+	}
 
-		case selectedMode == STATUS:
-			return menuOrder[0]
+	if chaser && !editStaticColorMode {
+		switch {
+		case currentMode == NORMAL:
+			return menuOrder[FUNCTION]
+
+		case currentMode == FUNCTION:
+			return menuOrder[CHASER_DISPLAY]
+
+		case currentMode == CHASER_DISPLAY:
+			return menuOrder[CHASER_FUNCTION]
+
+		case currentMode == CHASER_FUNCTION:
+			return menuOrder[STATUS]
+
+		case currentMode == STATUS:
+			return menuOrder[NORMAL]
+		}
+	}
+
+	if chaser && editStaticColorMode {
+		switch {
+		case currentMode == NORMAL:
+			return menuOrder[FUNCTION]
+
+		case currentMode == FUNCTION:
+			return menuOrder[CHASER_DISPLAY]
+
+		case currentMode == CHASER_DISPLAY:
+			return menuOrder[CHASER_DISPLAY_STATIC]
+
+		case currentMode == CHASER_DISPLAY_STATIC:
+			return menuOrder[CHASER_FUNCTION]
+
+		case currentMode == CHASER_FUNCTION:
+			return menuOrder[STATUS]
+
+		case currentMode == STATUS:
+			return menuOrder[NORMAL]
 		}
 	}
 

--- a/pkg/buttons/menu.go
+++ b/pkg/buttons/menu.go
@@ -1,0 +1,53 @@
+package buttons
+
+// Create a sequence of menu items based on if chaser is running.
+func newMenu(chaser bool) []int {
+
+	if !chaser {
+		return []int{NORMAL, FUNCTION, STATUS}
+	} else {
+		return []int{NORMAL, FUNCTION, CHASER_DISPLAY, CHASER_FUNCTION, STATUS}
+	}
+
+}
+
+// getNextMenuItem get the next items in the menu sequence.
+// Wraps if your at the end.
+func getNextMenuItem(selectedMode int, chaser bool) int {
+
+	menuOrder := newMenu(chaser)
+
+	if !chaser {
+		switch {
+		case selectedMode == NORMAL:
+			return menuOrder[1]
+
+		case selectedMode == FUNCTION:
+			return menuOrder[2]
+
+		case selectedMode == STATUS:
+			return menuOrder[0]
+		}
+	}
+
+	if chaser {
+		switch {
+		case selectedMode == NORMAL:
+			return menuOrder[1]
+
+		case selectedMode == FUNCTION:
+			return menuOrder[2]
+
+		case selectedMode == CHASER_DISPLAY:
+			return menuOrder[3]
+
+		case selectedMode == CHASER_FUNCTION:
+			return menuOrder[4]
+
+		case selectedMode == STATUS:
+			return menuOrder[0]
+		}
+	}
+
+	return 0
+}

--- a/pkg/buttons/menu_test.go
+++ b/pkg/buttons/menu_test.go
@@ -1,47 +1,14 @@
 package buttons
 
 import (
-	"reflect"
 	"testing"
 )
 
-func Test_newMenu(t *testing.T) {
-	type args struct {
-		chaser bool
-	}
-	tests := []struct {
-		name string
-		args args
-		want []int
-	}{
-		{
-			name: "not a chaser",
-			args: args{
-				chaser: false,
-			},
-			want: []int{NORMAL, FUNCTION, STATUS},
-		},
-		{
-			name: "is a chaser",
-			args: args{
-				chaser: true,
-			},
-			want: []int{NORMAL, FUNCTION, CHASER_DISPLAY, CHASER_FUNCTION, STATUS},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := newMenu(tt.args.chaser); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("newMenu() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func Test_getNextMenuItem(t *testing.T) {
 	type args struct {
-		selectedMode int
-		chaser       bool
+		selectedMode    int
+		chaser          bool
+		editstaticcolor bool
 	}
 	tests := []struct {
 		name string
@@ -49,75 +16,83 @@ func Test_getNextMenuItem(t *testing.T) {
 		want int
 	}{
 		{
-			name: "get next item, normal in not a chaser mode,",
+			name: "get next item, send normal want function",
 			args: args{
-				selectedMode: NORMAL,
-				chaser:       false,
+				selectedMode:    NORMAL,
+				chaser:          false,
+				editstaticcolor: false,
 			},
 			want: FUNCTION,
 		},
 		{
-			name: "get next item, normal in not a chaser mode,",
+			name: "get next item, send function want status",
 			args: args{
-				selectedMode: FUNCTION,
-				chaser:       false,
+				selectedMode:    FUNCTION,
+				chaser:          false,
+				editstaticcolor: false,
 			},
 			want: STATUS,
 		},
 		{
-			name: "get next item, normal in not a chaser mode,",
+			name: "get next item, send status want normal",
 			args: args{
-				selectedMode: STATUS,
-				chaser:       false,
+				selectedMode:    STATUS,
+				chaser:          false,
+				editstaticcolor: false,
 			},
 			want: NORMAL,
 		},
 
 		// Chaser mode.
 		{
-			name: "get next item, normal and in chaser mode,",
+			name: "get next item, send normal want function",
 			args: args{
-				selectedMode: NORMAL,
-				chaser:       true,
+				selectedMode:    NORMAL,
+				chaser:          true,
+				editstaticcolor: false,
 			},
 			want: FUNCTION,
 		},
 		{
-			name: "get next item, function and in chaser mode,",
+			name: "get next item, send function chaser display",
 			args: args{
-				selectedMode: FUNCTION,
-				chaser:       true,
+				selectedMode:    FUNCTION,
+				chaser:          true,
+				editstaticcolor: false,
 			},
 			want: CHASER_DISPLAY,
 		},
 		{
-			name: "get next item, chaser display and in chaser mode,",
+			name: "get next item, send chaser display want chaser function",
 			args: args{
-				selectedMode: CHASER_DISPLAY,
-				chaser:       true,
+				selectedMode:    CHASER_DISPLAY,
+				chaser:          true,
+				editstaticcolor: false,
 			},
 			want: CHASER_FUNCTION,
 		},
 		{
-			name: "get next item, chaser function and in chaser mode,",
+			name: "get next item, send chaser function want status",
 			args: args{
-				selectedMode: CHASER_FUNCTION,
-				chaser:       true,
+				selectedMode:    CHASER_FUNCTION,
+				chaser:          true,
+				editstaticcolor: false,
 			},
 			want: STATUS,
 		},
 		{
-			name: "get next item, status and in chaser mode,",
+			name: "get next item, send status want normal,",
 			args: args{
-				selectedMode: STATUS,
-				chaser:       true,
+				selectedMode:    STATUS,
+				chaser:          true,
+				editstaticcolor: false,
 			},
 			want: NORMAL,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getNextMenuItem(tt.args.selectedMode, tt.args.chaser); got != tt.want {
+			if got := getNextMenuItem(tt.args.selectedMode, tt.args.chaser, tt.args.editstaticcolor); got != tt.want {
 				t.Errorf("getNextMenuItem() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/buttons/menu_test.go
+++ b/pkg/buttons/menu_test.go
@@ -1,0 +1,125 @@
+package buttons
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_newMenu(t *testing.T) {
+	type args struct {
+		chaser bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want []int
+	}{
+		{
+			name: "not a chaser",
+			args: args{
+				chaser: false,
+			},
+			want: []int{NORMAL, FUNCTION, STATUS},
+		},
+		{
+			name: "is a chaser",
+			args: args{
+				chaser: true,
+			},
+			want: []int{NORMAL, FUNCTION, CHASER_DISPLAY, CHASER_FUNCTION, STATUS},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := newMenu(tt.args.chaser); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("newMenu() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_getNextMenuItem(t *testing.T) {
+	type args struct {
+		selectedMode int
+		chaser       bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want int
+	}{
+		{
+			name: "get next item, normal in not a chaser mode,",
+			args: args{
+				selectedMode: NORMAL,
+				chaser:       false,
+			},
+			want: FUNCTION,
+		},
+		{
+			name: "get next item, normal in not a chaser mode,",
+			args: args{
+				selectedMode: FUNCTION,
+				chaser:       false,
+			},
+			want: STATUS,
+		},
+		{
+			name: "get next item, normal in not a chaser mode,",
+			args: args{
+				selectedMode: STATUS,
+				chaser:       false,
+			},
+			want: NORMAL,
+		},
+
+		// Chaser mode.
+		{
+			name: "get next item, normal and in chaser mode,",
+			args: args{
+				selectedMode: NORMAL,
+				chaser:       true,
+			},
+			want: FUNCTION,
+		},
+		{
+			name: "get next item, function and in chaser mode,",
+			args: args{
+				selectedMode: FUNCTION,
+				chaser:       true,
+			},
+			want: CHASER_DISPLAY,
+		},
+		{
+			name: "get next item, chaser display and in chaser mode,",
+			args: args{
+				selectedMode: CHASER_DISPLAY,
+				chaser:       true,
+			},
+			want: CHASER_FUNCTION,
+		},
+		{
+			name: "get next item, chaser function and in chaser mode,",
+			args: args{
+				selectedMode: CHASER_FUNCTION,
+				chaser:       true,
+			},
+			want: STATUS,
+		},
+		{
+			name: "get next item, status and in chaser mode,",
+			args: args{
+				selectedMode: STATUS,
+				chaser:       true,
+			},
+			want: NORMAL,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getNextMenuItem(tt.args.selectedMode, tt.args.chaser); got != tt.want {
+				t.Errorf("getNextMenuItem() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -404,7 +404,6 @@ func ListenCommandChannelAndWait(mySequenceNumber int, currentSpeed time.Duratio
 			sequence.PlayStaticOnce = true
 		}
 		// Restore the state of the music trigger flag.
-		//sequence.Functions[common.Function8_Music_Trigger].State = sequence.LastMusicTrigger
 		sequence.MusicTrigger = sequence.LastMusicTrigger
 		return sequence
 

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -188,15 +188,15 @@ func ListenCommandChannelAndWait(mySequenceNumber int, currentSpeed time.Duratio
 		if debug {
 			fmt.Printf("%d: Command UnHide\n", mySequenceNumber)
 		}
-		if sequence.Hidden {
-			if debug {
-				fmt.Printf("%d: Command Actually UnHide Run is %t Static is %t\n", mySequenceNumber, sequence.Run, sequence.Static)
-			}
-			sequence.Hide = false
-			sequence.Hidden = false
-			sequence.PlayStaticOnce = true
-			sequence.PlaySwitchOnce = true
+		//if sequence.Hidden {
+		if debug {
+			fmt.Printf("%d: Command Actually UnHide Run is %t Static is %t\n", mySequenceNumber, sequence.Run, sequence.Static)
 		}
+		sequence.Hide = false
+		sequence.Hidden = false
+		sequence.PlayStaticOnce = true
+		sequence.PlaySwitchOnce = true
+		//}
 
 		return sequence
 

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -457,7 +457,6 @@ func ListenCommandChannelAndWait(mySequenceNumber int, currentSpeed time.Duratio
 		sequence.PlayStaticOnce = true
 		sequence.PlaySwitchOnce = true
 		sequence.StaticFadeOnce = false
-		sequence.Hidden = false
 		sequence.Static = command.Args[STATIC].Value.(bool)
 		sequence.Run = false
 		return sequence

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -181,6 +181,10 @@ func ListenCommandChannelAndWait(mySequenceNumber int, currentSpeed time.Duratio
 			}
 			sequence.Hide = true
 			sequence.Hidden = true
+		} else {
+			if debug {
+				fmt.Printf("%d: Command Failed to Hide Run is %t Static is %t\n", mySequenceNumber, sequence.Run, sequence.Static)
+			}
 		}
 		return sequence
 
@@ -197,6 +201,10 @@ func ListenCommandChannelAndWait(mySequenceNumber int, currentSpeed time.Duratio
 			sequence.Hidden = false
 			sequence.PlayStaticOnce = true
 			sequence.PlaySwitchOnce = true
+		} else {
+			if debug {
+				fmt.Printf("%d: Command Failed to UnHide Run is %t Static is %t\n", mySequenceNumber, sequence.Run, sequence.Static)
+			}
 		}
 
 		return sequence

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -464,6 +464,7 @@ func ListenCommandChannelAndWait(mySequenceNumber int, currentSpeed time.Duratio
 
 	case common.UpdateFlashAllStaticColorButtons:
 		const STATIC_FLASH = 0
+		const STATIC_HIDDEN = 1
 		if debug {
 			fmt.Printf("%d: Command Flash All Static Colors to %t\n", mySequenceNumber, command.Args[STATIC_FLASH].Value)
 		}
@@ -473,7 +474,7 @@ func ListenCommandChannelAndWait(mySequenceNumber int, currentSpeed time.Duratio
 		sequence.StaticFadeOnce = false // We don't want to fade as we set colors.
 		sequence.PlayStaticOnce = true
 		sequence.Static = true
-		sequence.Hide = false
+		sequence.Hide = command.Args[STATIC_HIDDEN].Value.(bool)
 		return sequence
 
 	case common.UpdateAllStaticColor:

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -796,6 +796,7 @@ func ListenCommandChannelAndWait(mySequenceNumber int, currentSpeed time.Duratio
 		}
 		sequence.UpdatePattern = true
 		sequence.Static = false
+		sequence.PlayStaticOnce = false
 		sequence.ChangeMusicTrigger = true
 		return sequence
 

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -177,7 +177,7 @@ func ListenCommandChannelAndWait(mySequenceNumber int, currentSpeed time.Duratio
 		}
 		if !sequence.Hidden {
 			if debug {
-				fmt.Printf("%d: Command Actually Hide\n", mySequenceNumber)
+				fmt.Printf("%d: Command Actually Hide Run is %t Static is %t\n", mySequenceNumber, sequence.Run, sequence.Static)
 			}
 			sequence.Hide = true
 			sequence.Hidden = true
@@ -190,7 +190,7 @@ func ListenCommandChannelAndWait(mySequenceNumber int, currentSpeed time.Duratio
 		}
 		if sequence.Hidden {
 			if debug {
-				fmt.Printf("%d: Command Actually UnHide\n", mySequenceNumber)
+				fmt.Printf("%d: Command Actually UnHide Run is %t Static is %t\n", mySequenceNumber, sequence.Run, sequence.Static)
 			}
 			sequence.Hide = false
 			sequence.Hidden = false

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -26,7 +26,7 @@ import (
 	"github.com/dhowlett99/dmxlights/pkg/fixture"
 )
 
-const debug = false
+const debug = true
 const beatDebug = false
 
 // listenCommandChannelAndWait listens on channel for instructions or timeout and go to next step of sequence.

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -582,7 +582,7 @@ func ListenCommandChannelAndWait(mySequenceNumber int, currentSpeed time.Duratio
 		sequence.StaticColors = common.SetDefaultStaticColorButtons(mySequenceNumber)
 		sequence.PlayStaticOnce = true
 		sequence.Static = true
-		sequence.Hide = true
+		sequence.Hide = false
 		return sequence
 
 	case common.SetStaticColorBar:

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -188,15 +188,16 @@ func ListenCommandChannelAndWait(mySequenceNumber int, currentSpeed time.Duratio
 		if debug {
 			fmt.Printf("%d: Command UnHide\n", mySequenceNumber)
 		}
-		//if sequence.Hidden {
-		if debug {
-			fmt.Printf("%d: Command Actually UnHide Run is %t Static is %t\n", mySequenceNumber, sequence.Run, sequence.Static)
+		// We must have called Hide before we UnHide.
+		if sequence.Hidden {
+			if debug {
+				fmt.Printf("%d: Command Actually UnHide Run is %t Static is %t\n", mySequenceNumber, sequence.Run, sequence.Static)
+			}
+			sequence.Hide = false
+			sequence.Hidden = false
+			sequence.PlayStaticOnce = true
+			sequence.PlaySwitchOnce = true
 		}
-		sequence.Hide = false
-		sequence.Hidden = false
-		sequence.PlayStaticOnce = true
-		sequence.PlaySwitchOnce = true
-		//}
 
 		return sequence
 

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -473,7 +473,32 @@ func ListenCommandChannelAndWait(mySequenceNumber int, currentSpeed time.Duratio
 		sequence.StaticFadeOnce = false // We don't want to fade as we set colors.
 		sequence.PlayStaticOnce = true
 		sequence.Static = true
+		sequence.Hide = false
+		return sequence
+
+	case common.UpdateAllStaticColor:
+		const STATIC = 0                // Boolean
+		const STATIC_FIXTURE_FLASH = 1  // Boolean
+		const STATIC_SELECTED_COLOR = 2 // Integer
+		const STATIC_COLOR = 3          // Color
+		if debug {
+			fmt.Printf("%d: Command Update All Static Colors\n", mySequenceNumber)
+			fmt.Printf("Selected Color:%d Flash:%t\n", command.Args[STATIC_SELECTED_COLOR].Value, command.Args[STATIC_FIXTURE_FLASH].Value)
+			fmt.Printf("Lamp Color   %+v\n", command.Args[STATIC_COLOR].Value.(common.Color))
+			fmt.Printf("Lamp Flash   %+v\n", command.Args[STATIC_FIXTURE_FLASH].Value.(common.Color))
+
+		}
+		// Set fixtures.
+		for fixture := 0; fixture < sequence.NumberFixtures; fixture++ {
+			sequence.StaticColors[fixture].SelectedColor = command.Args[STATIC_SELECTED_COLOR].Value.(int)
+			sequence.StaticColors[fixture].Color = command.Args[STATIC_COLOR].Value.(common.Color)
+			sequence.StaticColors[fixture].Flash = command.Args[STATIC_FIXTURE_FLASH].Value.(bool)
+		}
+		sequence.StaticFadeOnce = false // We don't want to fade as we set colors.
+		sequence.PlayStaticOnce = true
+		sequence.Static = command.Args[STATIC].Value.(bool)
 		sequence.Hide = true
+
 		return sequence
 
 	case common.UpdateStaticColor:

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -485,7 +485,7 @@ func ListenCommandChannelAndWait(mySequenceNumber int, currentSpeed time.Duratio
 			fmt.Printf("%d: Command Update All Static Colors\n", mySequenceNumber)
 			fmt.Printf("Selected Color:%d Flash:%t\n", command.Args[STATIC_SELECTED_COLOR].Value, command.Args[STATIC_FIXTURE_FLASH].Value)
 			fmt.Printf("Lamp Color   %+v\n", command.Args[STATIC_COLOR].Value.(common.Color))
-			fmt.Printf("Lamp Flash   %+v\n", command.Args[STATIC_FIXTURE_FLASH].Value.(common.Color))
+			fmt.Printf("Lamp Flash   %+v\n", command.Args[STATIC_FIXTURE_FLASH].Value.(bool))
 
 		}
 		// Set fixtures.

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -302,6 +302,7 @@ func ListenCommandChannelAndWait(mySequenceNumber int, currentSpeed time.Duratio
 		sequence.Mode = "Sequence"
 		sequence.Static = false
 		sequence.Run = true
+		sequence.Hidden = true // Make sure the next call to unHide works.
 		return sequence
 
 	case common.StartChase:
@@ -597,15 +598,6 @@ func ListenCommandChannelAndWait(mySequenceNumber int, currentSpeed time.Duratio
 			fmt.Printf("%d: Command Get Updated Sequence\n", mySequenceNumber)
 		}
 		updateChannel <- sequence
-		return sequence
-
-	// Update function mode for the current sequence.
-	case common.UpdateFunctionMode:
-		const FUNCTION_MODE = 0
-		if debug {
-			fmt.Printf("%d: Command Update Function Mode %t\n", mySequenceNumber, command.Args[FUNCTION_MODE].Value)
-		}
-		sequence.FunctionMode = command.Args[FUNCTION_MODE].Value.(bool)
 		return sequence
 
 	// Clear switch positions for this sequence

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -26,7 +26,7 @@ import (
 	"github.com/dhowlett99/dmxlights/pkg/fixture"
 )
 
-const debug = true
+const debug = false
 const beatDebug = false
 
 // listenCommandChannelAndWait listens on channel for instructions or timeout and go to next step of sequence.

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -223,6 +223,7 @@ const (
 	UpdateStatic
 	UpdateFlashAllStaticColorButtons
 	UpdateBounce
+	UpdateAllStaticColor
 	UpdateStaticColor
 	UpdateASingeSequenceColor
 	UpdateSequenceColors

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -961,16 +961,6 @@ func RefreshSequence(selectedSequence int, commandChannels []chan Command, updat
 	return &newSequence
 }
 
-// For the given sequence hide the available sequence colors..
-func HideColorSelectionButtons(mySequenceNumber int, sequence Sequence, eventsForLauchpad chan ALight, guiButtons chan ALight) {
-	if mySequenceNumber == 4 {
-		return
-	}
-	for myFixtureNumber := range sequence.RGBAvailableColors {
-		LightLamp(ALight{X: myFixtureNumber, Y: mySequenceNumber, Red: 0, Green: 0, Blue: 0, Brightness: sequence.Master}, eventsForLauchpad, guiButtons)
-	}
-}
-
 func ClearSelectedRowOfButtons(selectedSequence int, eventsForLauchpad chan ALight, guiButtons chan ALight) {
 	if selectedSequence == 4 {
 		return

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -246,8 +246,6 @@ const (
 	SoftFadeOn
 	SoftFadeOff
 	UpdateColor
-	UpdateFunctionMode
-	FunctionMode
 	UpdateFunctions
 	GetUpdatedSequence
 	ClearAllSwitchPositions
@@ -386,7 +384,6 @@ type Sequence struct {
 	UpdateShift                 bool                        // Command to update the shift.
 	UpdatePattern               bool                        // Flag to indicate we're going to change the RGB pattern.
 	UpdateSequenceColor         bool                        // Command to update the sequence colors.
-	FunctionMode                bool                        // This sequence is in function mode.
 	Switches                    map[int]Switch              // A switch sequence stores its data in here.
 	CurrentSwitch               int                         // Play this current switch position.
 	Optimisation                bool                        // Flag to decide on calculatePositions Optimisation.

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -1078,8 +1078,8 @@ func ShowBottomButtons(tYpe string, eventsForLauchpad chan ALight, guiButtons ch
 	guiBottomScannerButtons[3] = bottonButton{Label: "Shift\nUp", Color: Cyan}
 	guiBottomScannerButtons[4] = bottonButton{Label: "Size\nDown", Color: Cyan}
 	guiBottomScannerButtons[5] = bottonButton{Label: "Size\nUp", Color: Cyan}
-	guiBottomScannerButtons[6] = bottonButton{Label: "Coord\nDown", Color: White}
-	guiBottomScannerButtons[7] = bottonButton{Label: "Coord\nUp", Color: White}
+	guiBottomScannerButtons[6] = bottonButton{Label: "Coord\nDown", Color: Cyan}
+	guiBottomScannerButtons[7] = bottonButton{Label: "Coord\nUp", Color: Cyan}
 
 	//  The bottom row of the Novation Launchpad.
 	bottomRow := 7
@@ -1184,6 +1184,28 @@ func UpdateStatusBar(status string, which string, hide bool, guiButtons chan ALi
 		Hidden:       hide,
 	}
 	guiButtons <- event
+}
+
+func UpdateBottomButtons(selectedType string, guiButtons chan ALight) {
+
+	LabelButton(0, 7, "Speed\nDown", guiButtons)
+	LabelButton(1, 7, "Speed\nUp", guiButtons)
+
+	LabelButton(2, 7, "Shift\nDown", guiButtons)
+	LabelButton(3, 7, "Shift\nUp", guiButtons)
+
+	LabelButton(4, 7, "Size\nDown", guiButtons)
+	LabelButton(5, 7, "Size\nUp", guiButtons)
+
+	if selectedType == "rgb" {
+		LabelButton(6, 7, "Fade\nSoft", guiButtons)
+		LabelButton(7, 7, "Fade\nSharp", guiButtons)
+	}
+
+	if selectedType == "scanner" {
+		LabelButton(6, 7, "Coord\nDown", guiButtons)
+		LabelButton(7, 7, "Coord\nUp", guiButtons)
+	}
 }
 
 func FlashLight(X int, Y int, onColor Color, offColor Color, eventsForLauchpad chan ALight, guiButtons chan ALight) {

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -1044,6 +1044,10 @@ func ShowTopButtons(tYpe string, eventsForLauchpad chan ALight, guiButtons chan 
 
 func ShowBottomButtons(tYpe string, eventsForLauchpad chan ALight, guiButtons chan ALight) {
 
+	if debug {
+		fmt.Printf("ShowBottomButtons\n")
+	}
+
 	type bottonButton struct {
 		Label string
 		Color Color

--- a/pkg/fixture/fixture.go
+++ b/pkg/fixture/fixture.go
@@ -399,46 +399,46 @@ func FixtureReceiver(
 
 				// Work out what to do with the launchpad lamps.
 				if !cmd.Hide {
-					if cmd.ScannerChaser && cmd.Label == "chaser" {
-						// We are chase mode, we want the buttons to be the color selected for this scanner.
-						// Remember that fixtures in the real world we start counting from 1 not 0.
-						// i.e. realFixture := myFixtureNumber + 1
-						// Find the color that has been selected for this fixture.
-						// selected color is an index into the scanner colors selected.
-						selectedColor := cmd.ScannerColor
+					// if cmd.ScannerChaser && cmd.Label == "chaser" {
+					// 	// We are chase mode, we want the buttons to be the color selected for this scanner.
+					// 	// Remember that fixtures in the real world we start counting from 1 not 0.
+					// 	// i.e. realFixture := myFixtureNumber + 1
+					// 	// Find the color that has been selected for this fixture.
+					// 	// selected color is an index into the scanner colors selected.
+					// 	selectedColor := cmd.ScannerColor
 
-						// Do we have a set of available colors for this fixture.
-						if len(cmd.ScannerAvailableColors) != 0 {
-							availableColors := cmd.ScannerAvailableColors
-							red := availableColors[selectedColor].Color.R
-							green := availableColors[selectedColor].Color.G
-							blue := availableColors[selectedColor].Color.B
-							common.LightLamp(common.ALight{X: myFixtureNumber, Y: cmd.SequenceNumber, Red: red, Green: green, Blue: blue, Brightness: fixture.Shutter}, eventsForLauchpad, guiButtons)
+					// 	// Do we have a set of available colors for this fixture.
+					// 	if len(cmd.ScannerAvailableColors) != 0 {
+					// 		availableColors := cmd.ScannerAvailableColors
+					// 		red := availableColors[selectedColor].Color.R
+					// 		green := availableColors[selectedColor].Color.G
+					// 		blue := availableColors[selectedColor].Color.B
+					// 		common.LightLamp(common.ALight{X: myFixtureNumber, Y: cmd.SequenceNumber, Red: red, Green: green, Blue: blue, Brightness: fixture.Shutter}, eventsForLauchpad, guiButtons)
+					// 		common.LabelButton(myFixtureNumber, cmd.SequenceNumber, "", guiButtons)
+					// 	} else {
+					// 		// If the pattern has colors use them.
+					// 		if fixture.Color != common.Black {
+					// 			common.LightLamp(common.ALight{X: myFixtureNumber, Y: cmd.SequenceNumber, Red: fixture.Color.R, Green: fixture.Color.G, Blue: fixture.Color.B, Brightness: cmd.Master}, eventsForLauchpad, guiButtons)
+					// 			common.LabelButton(myFixtureNumber, cmd.SequenceNumber, "", guiButtons)
+					// 		} else {
+					// 			// No color selected or available, use white.
+					// 			common.LightLamp(common.ALight{X: myFixtureNumber, Y: cmd.SequenceNumber, Red: 222, Green: 255, Blue: 255, Brightness: fixture.Shutter}, eventsForLauchpad, guiButtons)
+					// 			common.LabelButton(myFixtureNumber, cmd.SequenceNumber, "", guiButtons)
+					// 		}
+					// 	}
+					// } else {
+					// Only fire every quarter turn of the scanner coordinates to save on launchpad mini traffic.
+					//if !cmd.ScannerChaser {
+					howOftern := cmd.NumberSteps / 4
+					if howOftern != 0 {
+						if cmd.Step%howOftern == 0 {
+							// We're not in chase mode so use the color generated in the pattern generator.common.
+							common.LightLamp(common.ALight{X: myFixtureNumber, Y: cmd.SequenceNumber, Red: fixture.Color.R, Green: fixture.Color.G, Blue: fixture.Color.B, Brightness: cmd.Master}, eventsForLauchpad, guiButtons)
 							common.LabelButton(myFixtureNumber, cmd.SequenceNumber, "", guiButtons)
-						} else {
-							// If the pattern has colors use them.
-							if fixture.Color != common.Black {
-								common.LightLamp(common.ALight{X: myFixtureNumber, Y: cmd.SequenceNumber, Red: fixture.Color.R, Green: fixture.Color.G, Blue: fixture.Color.B, Brightness: cmd.Master}, eventsForLauchpad, guiButtons)
-								common.LabelButton(myFixtureNumber, cmd.SequenceNumber, "", guiButtons)
-							} else {
-								// No color selected or available, use white.
-								common.LightLamp(common.ALight{X: myFixtureNumber, Y: cmd.SequenceNumber, Red: 222, Green: 255, Blue: 255, Brightness: fixture.Shutter}, eventsForLauchpad, guiButtons)
-								common.LabelButton(myFixtureNumber, cmd.SequenceNumber, "", guiButtons)
-							}
-						}
-					} else {
-						// Only fire every quarter turn of the scanner coordinates to save on launchpad mini traffic.
-						if !cmd.ScannerChaser {
-							howOftern := cmd.NumberSteps / 4
-							if howOftern != 0 {
-								if cmd.Step%howOftern == 0 {
-									// We're not in chase mode so use the color generated in the pattern generator.common.
-									common.LightLamp(common.ALight{X: myFixtureNumber, Y: cmd.SequenceNumber, Red: fixture.Color.R, Green: fixture.Color.G, Blue: fixture.Color.B, Brightness: cmd.Master}, eventsForLauchpad, guiButtons)
-									common.LabelButton(myFixtureNumber, cmd.SequenceNumber, "", guiButtons)
-								}
-							}
 						}
 					}
+					//}
+					//}
 				}
 			} else {
 				// This scanner is disabled, shut it off.

--- a/pkg/fixture/fixture.go
+++ b/pkg/fixture/fixture.go
@@ -303,7 +303,7 @@ func FixtureReceiver(
 					sequence.Number = cmd.SequenceNumber
 					sequence.Master = cmd.Master
 					sequence.Blackout = cmd.Blackout
-					sequence.Hide = false
+					sequence.Hide = cmd.Hide
 					sequence.StaticColors = cmd.RGBStaticColors
 					sequence.Static = cmd.RGBStatic
 					sequence.StrobeSpeed = cmd.StrobeSpeed

--- a/pkg/fixture/fixture.go
+++ b/pkg/fixture/fixture.go
@@ -397,38 +397,9 @@ func FixtureReceiver(
 				MapFixtures(false, cmd.ScannerChaser, cmd.SequenceNumber, dmxController, myFixtureNumber, fixture.ScannerColor.R, fixture.ScannerColor.G, fixture.ScannerColor.B, fixture.ScannerColor.W, fixture.ScannerColor.A, fixture.ScannerColor.UV, fixture.Pan, fixture.Tilt,
 					fixture.Shutter, cmd.Rotate, cmd.Music, cmd.Program, cmd.ScannerGobo, cmd.ScannerColor, fixtures, cmd.Blackout, cmd.Master, scannerBrightness, cmd.Strobe, cmd.StrobeSpeed, dmxInterfacePresent)
 
-				// Work out what to do with the launchpad lamps.
+				// Scannner is rotating, work out what to do with the launchpad lamps.
 				if !cmd.Hide {
-					// if cmd.ScannerChaser && cmd.Label == "chaser" {
-					// 	// We are chase mode, we want the buttons to be the color selected for this scanner.
-					// 	// Remember that fixtures in the real world we start counting from 1 not 0.
-					// 	// i.e. realFixture := myFixtureNumber + 1
-					// 	// Find the color that has been selected for this fixture.
-					// 	// selected color is an index into the scanner colors selected.
-					// 	selectedColor := cmd.ScannerColor
-
-					// 	// Do we have a set of available colors for this fixture.
-					// 	if len(cmd.ScannerAvailableColors) != 0 {
-					// 		availableColors := cmd.ScannerAvailableColors
-					// 		red := availableColors[selectedColor].Color.R
-					// 		green := availableColors[selectedColor].Color.G
-					// 		blue := availableColors[selectedColor].Color.B
-					// 		common.LightLamp(common.ALight{X: myFixtureNumber, Y: cmd.SequenceNumber, Red: red, Green: green, Blue: blue, Brightness: fixture.Shutter}, eventsForLauchpad, guiButtons)
-					// 		common.LabelButton(myFixtureNumber, cmd.SequenceNumber, "", guiButtons)
-					// 	} else {
-					// 		// If the pattern has colors use them.
-					// 		if fixture.Color != common.Black {
-					// 			common.LightLamp(common.ALight{X: myFixtureNumber, Y: cmd.SequenceNumber, Red: fixture.Color.R, Green: fixture.Color.G, Blue: fixture.Color.B, Brightness: cmd.Master}, eventsForLauchpad, guiButtons)
-					// 			common.LabelButton(myFixtureNumber, cmd.SequenceNumber, "", guiButtons)
-					// 		} else {
-					// 			// No color selected or available, use white.
-					// 			common.LightLamp(common.ALight{X: myFixtureNumber, Y: cmd.SequenceNumber, Red: 222, Green: 255, Blue: 255, Brightness: fixture.Shutter}, eventsForLauchpad, guiButtons)
-					// 			common.LabelButton(myFixtureNumber, cmd.SequenceNumber, "", guiButtons)
-					// 		}
-					// 	}
-					// } else {
-					// Only fire every quarter turn of the scanner coordinates to save on launchpad mini traffic.
-					//if !cmd.ScannerChaser {
+					// Every quater turn, display a color to represent a position in the rotation.
 					howOftern := cmd.NumberSteps / 4
 					if howOftern != 0 {
 						if cmd.Step%howOftern == 0 {
@@ -437,8 +408,6 @@ func FixtureReceiver(
 							common.LabelButton(myFixtureNumber, cmd.SequenceNumber, "", guiButtons)
 						}
 					}
-					//}
-					//}
 				}
 			} else {
 				// This scanner is disabled, shut it off.

--- a/pkg/sequence/sequence.go
+++ b/pkg/sequence/sequence.go
@@ -1075,12 +1075,3 @@ func getAvailableScannerPattens(sequence common.Sequence) map[int]common.Pattern
 	return scannerPattens
 
 }
-
-func SequenceSelect(eventsForLauchpad chan common.ALight, guiButtons chan common.ALight, selectedSequence int) {
-	// Turn off all sequence lights.
-	for seq := 0; seq < 3; seq++ {
-		common.LightLamp(common.ALight{X: 8, Y: seq, Brightness: 255, Red: 100, Green: 255, Blue: 255}, eventsForLauchpad, guiButtons)
-	}
-	// Now turn pink the selected sequence select light.
-	common.LightLamp(common.ALight{X: 8, Y: selectedSequence, Brightness: 255, Red: 255, Green: 0, Blue: 255}, eventsForLauchpad, guiButtons)
-}


### PR DESCRIPTION
Since we added the scan and chase feature, we didn't have a way to switch from rotation view and shutter chase on the sequence buttons.

This PR allows the select button to switch neatly  between modes.